### PR TITLE
[FE]모집페이지 - 카테고리 목록 필터 박스

### DIFF
--- a/client/src/components/SearchFilter/SearchBar.tsx
+++ b/client/src/components/SearchFilter/SearchBar.tsx
@@ -5,11 +5,11 @@ import { ReducerType } from '../../store/rootReducer';
 import {
   changeTechStackInput,
   groupRecruitType,
-  returnGroupTechStack,
-} from '../../store/slices/groupTechStackList';
+  returnGroupRecruitState,
+} from '../../store/slices/groupRecruitSlice';
 
 function SearchBar(): JSX.Element {
-  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupTechStack);
+  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
   const dispatch = useDispatch();
 
   const handleInputText = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/components/SearchFilter/SearchBar.tsx
+++ b/client/src/components/SearchFilter/SearchBar.tsx
@@ -5,11 +5,13 @@ import { ReducerType } from '../../store/rootReducer';
 import {
   changeTechStackInput,
   groupRecruitType,
-  returnGroupRecruitState,
-} from '../../store/slices/groupRecruitSlice';
+  returnGroupRecruitFilterState,
+} from '../../store/slices/groupRecruitFilterSlice';
 
 function SearchBar(): JSX.Element {
-  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
+  const techStackInput = useSelector<ReducerType, groupRecruitType>(
+    returnGroupRecruitFilterState,
+  ).techStackInput;
   const dispatch = useDispatch();
 
   const handleInputText = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -18,11 +20,7 @@ function SearchBar(): JSX.Element {
 
   return (
     <Container>
-      <InputValue
-        placeholder="Search for.."
-        value={groupTechStackList.techStackInput}
-        onChange={handleInputText}
-      />
+      <InputValue placeholder="Search for.." value={techStackInput} onChange={handleInputText} />
     </Container>
   );
 }

--- a/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
@@ -25,10 +25,28 @@ function CategoryList(): JSX.Element {
     getData();
   }, []);
 
+  const handleSelectedCategoryClick = () => {
+    groupRecruitDispatch(checkCategory(''));
+  };
+
+  const handleNonSelectedCategoryClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const selectedCategory = e.currentTarget.innerText;
+    groupRecruitDispatch(checkCategory(selectedCategory));
+  };
+
   const categoryItems = baseCategoryList.map((category) => {
     if (category.name === groupRecruitState.selectedCategory)
-      return <CategoryItemSelect key={category.id}>{category.name}</CategoryItemSelect>;
-    else return <CategoryItemNonSelect key={category.id}>{category.name}</CategoryItemNonSelect>;
+      return (
+        <CategoryItemSelect onClick={handleSelectedCategoryClick} key={category.id}>
+          {category.name}
+        </CategoryItemSelect>
+      );
+    else
+      return (
+        <CategoryItemNonSelect onClick={handleNonSelectedCategoryClick} key={category.id}>
+          {category.name}
+        </CategoryItemNonSelect>
+      );
   });
 
   return <Container>{categoryItems}</Container>;
@@ -40,13 +58,16 @@ const Container = styled.div`
   align-items: center;
 `;
 
-const CategoryItem = styled.div`
+const CategoryItem = styled.button`
   display: flex;
   margin: 5px;
   padding: 10px;
 
   box-shadow: 10px 10px 10px -5px rgba(41, 36, 36, 0.25);
   border-radius: 10px;
+  outline: none;
+  border: none;
+  cursor: pointer;
 `;
 
 const CategoryItemNonSelect = styled(CategoryItem)`

--- a/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
@@ -5,14 +5,16 @@ import { Category } from '../../../types';
 import { useDispatch, useSelector } from 'react-redux';
 import { ReducerType } from '../../../store/rootReducer';
 import {
-  returnGroupRecruitState,
+  returnGroupRecruitFilterState,
   groupRecruitType,
   checkCategory,
-} from '../../../store/slices/groupRecruitSlice';
+} from '../../../store/slices/groupRecruitFilterSlice';
 
 function CategoryList(): JSX.Element {
   const [baseCategoryList, setBaseCategoryList] = useState<Category[]>([]);
-  const groupRecruitState = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
+  const selectedCategory = useSelector<ReducerType, groupRecruitType>(
+    returnGroupRecruitFilterState,
+  ).selectedCategory;
   const groupRecruitDispatch = useDispatch();
 
   useEffect(() => {
@@ -35,7 +37,7 @@ function CategoryList(): JSX.Element {
   };
 
   const categoryItems = baseCategoryList.map((category) => {
-    if (category.name === groupRecruitState.selectedCategory)
+    if (category.name === selectedCategory)
       return (
         <CategoryItemSelect onClick={handleSelectedCategoryClick} key={category.id}>
           {category.name}

--- a/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
@@ -1,22 +1,33 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
-
-const dummyData = [
-  '공모전',
-  '프로젝트',
-  '대외활동',
-  '스터디',
-  '동아리',
-  '면접/인터뷰',
-  '토이프로젝트',
-  '구인/구직',
-  '기타',
-];
-
+import { getCategories } from '../../../api/category';
+import { Category } from '../../../types';
+import { useDispatch, useSelector } from 'react-redux';
+import { ReducerType } from '../../../store/rootReducer';
+import {
+  returnGroupRecruitState,
+  groupRecruitType,
+  checkCategory,
+} from '../../../store/slices/groupRecruitSlice';
 function CategoryList(): JSX.Element {
-  const categoryItems = dummyData.map((category, idx) => {
-    if (idx === 4) return <CategoryItemSelect key={category}>{category}</CategoryItemSelect>;
-    else return <CategoryItem key={idx}>{category}</CategoryItem>;
+  const [baseCategoryList, setBaseCategoryList] = useState<Category[]>([]);
+  const groupRecruitState = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
+  const groupRecruitDispatch = useDispatch();
+
+  useEffect(() => {
+    const { category } = history.state.state ?? { category: '' };
+    const getData = async () => {
+      const categoryList = await getCategories();
+      setBaseCategoryList(categoryList);
+      groupRecruitDispatch(checkCategory(category));
+    };
+    getData();
+  }, []);
+
+  const categoryItems = baseCategoryList.map((category) => {
+    if (category.name === groupRecruitState.selectedCategory)
+      return <CategoryItemSelect key={category.id}>{category.name}</CategoryItemSelect>;
+    else return <CategoryItem key={category.id}>{category.name}</CategoryItem>;
   });
 
   return <Container>{categoryItems}</Container>;

--- a/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
@@ -9,6 +9,7 @@ import {
   groupRecruitType,
   checkCategory,
 } from '../../../store/slices/groupRecruitSlice';
+
 function CategoryList(): JSX.Element {
   const [baseCategoryList, setBaseCategoryList] = useState<Category[]>([]);
   const groupRecruitState = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
@@ -27,7 +28,7 @@ function CategoryList(): JSX.Element {
   const categoryItems = baseCategoryList.map((category) => {
     if (category.name === groupRecruitState.selectedCategory)
       return <CategoryItemSelect key={category.id}>{category.name}</CategoryItemSelect>;
-    else return <CategoryItem key={category.id}>{category.name}</CategoryItem>;
+    else return <CategoryItemNonSelect key={category.id}>{category.name}</CategoryItemNonSelect>;
   });
 
   return <Container>{categoryItems}</Container>;
@@ -44,21 +45,18 @@ const CategoryItem = styled.div`
   margin: 5px;
   padding: 10px;
 
-  color: ${(props) => props.theme.White};
-  background: ${(props) => props.theme.Gray5};
   box-shadow: 10px 10px 10px -5px rgba(41, 36, 36, 0.25);
   border-radius: 10px;
 `;
 
-const CategoryItemSelect = styled.div`
-  display: flex;
-  margin: 5px;
-  padding: 10px;
+const CategoryItemNonSelect = styled(CategoryItem)`
+  color: ${(props) => props.theme.White};
+  background: ${(props) => props.theme.Gray5};
+`;
 
+const CategoryItemSelect = styled(CategoryItem)`
   color: ${(props) => props.theme.White};
   background: ${(props) => props.theme.Primary};
-  box-shadow: 10px 10px 10px -5px rgba(41, 36, 36, 0.25);
-  border-radius: 10px;
 `;
 
 export default CategoryList;

--- a/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterHeader/CategoryList.tsx
@@ -19,12 +19,12 @@ function CategoryList(): JSX.Element {
 
   useEffect(() => {
     const { category } = history.state.state ?? { category: '' };
-    const getData = async () => {
+    const getCategoryListData = async () => {
       const categoryList = await getCategories();
       setBaseCategoryList(categoryList);
       groupRecruitDispatch(checkCategory(category));
     };
-    getData();
+    getCategoryListData();
   }, []);
 
   const handleSelectedCategoryClick = () => {

--- a/client/src/components/SearchFilter/SearchFilterTechSection/SelectedTechList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterTechSection/SelectedTechList.tsx
@@ -5,11 +5,13 @@ import { ReducerType } from '../../../store/rootReducer';
 import {
   popSelectedTechStack,
   groupRecruitType,
-  returnGroupRecruitState,
-} from '../../../store/slices/groupRecruitSlice';
+  returnGroupRecruitFilterState,
+} from '../../../store/slices/groupRecruitFilterSlice';
 
 function SelectedTechList(): JSX.Element {
-  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
+  const selectedTechStack = useSelector<ReducerType, groupRecruitType>(
+    returnGroupRecruitFilterState,
+  ).selectedTechStack;
 
   const selectedTechStackDispatch = useDispatch();
 
@@ -19,7 +21,7 @@ function SelectedTechList(): JSX.Element {
     selectedTechStackDispatch(popSelectedTechStack(nowTechStack));
   };
 
-  const totalSelectedTechList = groupTechStackList.selectedTechStack.map((category, idx) => {
+  const totalSelectedTechList = selectedTechStack.map((category, idx) => {
     return (
       <SelectItem key={idx}>
         <h4>{category}</h4>

--- a/client/src/components/SearchFilter/SearchFilterTechSection/SelectedTechList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterTechSection/SelectedTechList.tsx
@@ -5,11 +5,11 @@ import { ReducerType } from '../../../store/rootReducer';
 import {
   popSelectedTechStack,
   groupRecruitType,
-  returnGroupTechStack,
-} from '../../../store/slices/groupTechStackList';
+  returnGroupRecruitState,
+} from '../../../store/slices/groupRecruitSlice';
 
 function SelectedTechList(): JSX.Element {
-  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupTechStack);
+  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
 
   const selectedTechStackDispatch = useDispatch();
 

--- a/client/src/components/SearchFilter/SearchFilterTechSection/TechList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterTechSection/TechList.tsx
@@ -6,8 +6,8 @@ import { ReducerType } from '../../../store/rootReducer';
 import {
   pushSelectedTechStack,
   groupRecruitType,
-  returnGroupRecruitState,
-} from '../../../store/slices/groupRecruitSlice';
+  returnGroupRecruitFilterState,
+} from '../../../store/slices/groupRecruitFilterSlice';
 import { TechStack } from '../../../types/TechStack';
 
 const MAX_SELECTED_INDEX = 5;
@@ -17,7 +17,9 @@ interface Props {
 }
 
 function TechList({ listView }: Props): JSX.Element {
-  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
+  const selectedTechStack = useSelector<ReducerType, groupRecruitType>(
+    returnGroupRecruitFilterState,
+  ).selectedTechStack;
   const selectedTechStackDispatch = useDispatch();
 
   const handleTechStackClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -26,13 +28,13 @@ function TechList({ listView }: Props): JSX.Element {
     clickedTechStack.classList.remove('shake');
     clickedTechStack.offsetWidth;
 
-    if (groupTechStackList.selectedTechStack.length >= MAX_SELECTED_INDEX) {
+    if (selectedTechStack.length >= MAX_SELECTED_INDEX) {
       clickedTechStack.classList.add('shake');
     } else selectedTechStackDispatch(pushSelectedTechStack(techStackName));
   };
 
   const techList = listView.map((category) => {
-    if (groupTechStackList.selectedTechStack.includes(category.name))
+    if (selectedTechStack.includes(category.name))
       return (
         <SelectedTechListItem key={category.id} onClick={handleTechStackClick}>
           {category.name}

--- a/client/src/components/SearchFilter/SearchFilterTechSection/TechList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterTechSection/TechList.tsx
@@ -6,8 +6,8 @@ import { ReducerType } from '../../../store/rootReducer';
 import {
   pushSelectedTechStack,
   groupRecruitType,
-  returnGroupTechStack,
-} from '../../../store/slices/groupTechStackList';
+  returnGroupRecruitState,
+} from '../../../store/slices/groupRecruitSlice';
 import { TechStack } from '../../../types/TechStack';
 
 const MAX_SELECTED_INDEX = 5;
@@ -17,7 +17,7 @@ interface Props {
 }
 
 function TechList({ listView }: Props): JSX.Element {
-  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupTechStack);
+  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
   const selectedTechStackDispatch = useDispatch();
 
   const handleTechStackClick = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/client/src/components/SearchFilter/SearchFilterTechSection/TechList.tsx
+++ b/client/src/components/SearchFilter/SearchFilterTechSection/TechList.tsx
@@ -34,13 +34,13 @@ function TechList({ listView }: Props): JSX.Element {
   const techList = listView.map((category) => {
     if (groupTechStackList.selectedTechStack.includes(category.name))
       return (
-        <SelectedTechListItem key={category.tech_stack_id} onClick={handleTechStackClick}>
+        <SelectedTechListItem key={category.id} onClick={handleTechStackClick}>
           {category.name}
         </SelectedTechListItem>
       );
     else {
       return (
-        <TechListItem key={category.tech_stack_id} onClick={handleTechStackClick}>
+        <TechListItem key={category.id} onClick={handleTechStackClick}>
           {category.name}
         </TechListItem>
       );

--- a/client/src/components/SearchFilter/SearchFilterTechSection/index.tsx
+++ b/client/src/components/SearchFilter/SearchFilterTechSection/index.tsx
@@ -6,10 +6,15 @@ import { useSelector } from 'react-redux';
 import { ReducerType } from '../../../store/rootReducer';
 import { getTechStackList } from '../../../api/techStack';
 import { TechStack } from '../../../types';
-import { groupRecruitType, returnGroupRecruitState } from '../../../store/slices/groupRecruitSlice';
+import {
+  groupRecruitType,
+  returnGroupRecruitFilterState,
+} from '../../../store/slices/groupRecruitFilterSlice';
 
 function SearchFilterTechSection(): JSX.Element {
-  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
+  const techStackInput = useSelector<ReducerType, groupRecruitType>(
+    returnGroupRecruitFilterState,
+  ).techStackInput;
   const [baseTechStackList, setBaseTechStackList] = useState<TechStack[]>([]);
   const [techListView, setTechListView] = useState<TechStack[]>([]);
 
@@ -23,10 +28,10 @@ function SearchFilterTechSection(): JSX.Element {
 
   useEffect(() => {
     const newTechList = baseTechStackList.filter((tech) => {
-      return tech.name.includes(groupTechStackList.techStackInput);
+      return tech.name.includes(techStackInput);
     });
     setTechListView(newTechList);
-  }, [groupTechStackList.techStackInput, baseTechStackList]);
+  }, [techStackInput, baseTechStackList]);
 
   return (
     <Container>

--- a/client/src/components/SearchFilter/SearchFilterTechSection/index.tsx
+++ b/client/src/components/SearchFilter/SearchFilterTechSection/index.tsx
@@ -5,7 +5,7 @@ import TechList from './TechList';
 import { useSelector } from 'react-redux';
 import { ReducerType } from '../../../store/rootReducer';
 import { getTechStackList } from '../../../api/techStack';
-import { TechStack } from '../../../types/TechStack';
+import { TechStack } from '../../../types';
 import { groupRecruitType, returnGroupRecruitState } from '../../../store/slices/groupRecruitSlice';
 
 function SearchFilterTechSection(): JSX.Element {
@@ -17,7 +17,6 @@ function SearchFilterTechSection(): JSX.Element {
     const getData = async () => {
       const data = await getTechStackList();
       setBaseTechStackList(data);
-      return data;
     };
     getData();
   }, []);

--- a/client/src/components/SearchFilter/SearchFilterTechSection/index.tsx
+++ b/client/src/components/SearchFilter/SearchFilterTechSection/index.tsx
@@ -6,10 +6,10 @@ import { useSelector } from 'react-redux';
 import { ReducerType } from '../../../store/rootReducer';
 import { getTechStackList } from '../../../api/techStack';
 import { TechStack } from '../../../types/TechStack';
-import { groupRecruitType, returnGroupTechStack } from '../../../store/slices/groupTechStackList';
+import { groupRecruitType, returnGroupRecruitState } from '../../../store/slices/groupRecruitSlice';
 
 function SearchFilterTechSection(): JSX.Element {
-  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupTechStack);
+  const groupTechStackList = useSelector<ReducerType, groupRecruitType>(returnGroupRecruitState);
   const [baseTechStackList, setBaseTechStackList] = useState<TechStack[]>([]);
   const [techListView, setTechListView] = useState<TechStack[]>([]);
 

--- a/client/src/pages/MainPage/CategoryItem.tsx
+++ b/client/src/pages/MainPage/CategoryItem.tsx
@@ -11,7 +11,7 @@ export default function CategoryItem({ id, name, url }: Props): JSX.Element {
   return (
     <LinkButton
       to={{
-        pathname: `/groups`,
+        pathname: `/recruit/group`,
         state: {
           id,
           category: name,

--- a/client/src/store/rootReducer.ts
+++ b/client/src/store/rootReducer.ts
@@ -1,8 +1,8 @@
 import { combineReducers } from '@reduxjs/toolkit';
-import groupTechStack from './slices/groupTechStackList';
+import groupRecruit from './slices/groupRecruitSlice';
 
 const reducer = combineReducers({
-  groupTechStack,
+  groupRecruit,
 });
 
 export type ReducerType = ReturnType<typeof reducer>;

--- a/client/src/store/rootReducer.ts
+++ b/client/src/store/rootReducer.ts
@@ -1,5 +1,5 @@
 import { combineReducers } from '@reduxjs/toolkit';
-import groupRecruit from './slices/groupRecruitSlice';
+import groupRecruit from './slices/groupRecruitFilterSlice';
 
 const reducer = combineReducers({
   groupRecruit,

--- a/client/src/store/slices/groupRecruitFilterSlice.ts
+++ b/client/src/store/slices/groupRecruitFilterSlice.ts
@@ -7,7 +7,7 @@ export interface groupRecruitType {
   selectedCategory: string;
 }
 
-export const groupRecruitSlice = createSlice({
+export const groupRecruitFilterSlice = createSlice({
   name: 'groupRecruit',
   initialState: {
     techStackInput: '' as string,
@@ -38,6 +38,7 @@ export const groupRecruitSlice = createSlice({
 });
 
 export const { changeTechStackInput, pushSelectedTechStack, popSelectedTechStack, checkCategory } =
-  groupRecruitSlice.actions;
-export default groupRecruitSlice.reducer;
-export const returnGroupRecruitState = (state: RootState): groupRecruitType => state.groupRecruit;
+  groupRecruitFilterSlice.actions;
+export default groupRecruitFilterSlice.reducer;
+export const returnGroupRecruitFilterState = (state: RootState): groupRecruitType =>
+  state.groupRecruit;

--- a/client/src/store/slices/groupRecruitSlice.ts
+++ b/client/src/store/slices/groupRecruitSlice.ts
@@ -6,8 +6,8 @@ export interface groupRecruitType {
   selectedTechStack: string[];
 }
 
-export const groupRecruitTechStackListSlice = createSlice({
-  name: 'groupRecruitTechStackList',
+export const groupRecruitSlice = createSlice({
+  name: 'groupRecruit',
   initialState: {
     techStackInput: '' as string,
     selectedTechStack: [] as string[],
@@ -33,6 +33,6 @@ export const groupRecruitTechStackListSlice = createSlice({
 });
 
 export const { changeTechStackInput, pushSelectedTechStack, popSelectedTechStack } =
-  groupRecruitTechStackListSlice.actions;
-export default groupRecruitTechStackListSlice.reducer;
-export const returnGroupTechStack = (state: RootState): groupRecruitType => state.groupTechStack;
+  groupRecruitSlice.actions;
+export default groupRecruitSlice.reducer;
+export const returnGroupRecruitState = (state: RootState): groupRecruitType => state.groupRecruit;

--- a/client/src/store/slices/groupRecruitSlice.ts
+++ b/client/src/store/slices/groupRecruitSlice.ts
@@ -4,6 +4,7 @@ import { RootState } from '../index';
 export interface groupRecruitType {
   techStackInput: string;
   selectedTechStack: string[];
+  selectedCategory: string;
 }
 
 export const groupRecruitSlice = createSlice({
@@ -11,6 +12,7 @@ export const groupRecruitSlice = createSlice({
   initialState: {
     techStackInput: '' as string,
     selectedTechStack: [] as string[],
+    selectedCategory: '' as string,
   },
   reducers: {
     changeTechStackInput(state, action) {
@@ -29,10 +31,13 @@ export const groupRecruitSlice = createSlice({
       );
       return { ...state, selectedTechStack: newSelectedTechStackList };
     },
+    checkCategory(state, action) {
+      return { ...state, selectedCategory: action.payload };
+    },
   },
 });
 
-export const { changeTechStackInput, pushSelectedTechStack, popSelectedTechStack } =
+export const { changeTechStackInput, pushSelectedTechStack, popSelectedTechStack, checkCategory } =
   groupRecruitSlice.actions;
 export default groupRecruitSlice.reducer;
 export const returnGroupRecruitState = (state: RootState): groupRecruitType => state.groupRecruit;

--- a/client/src/types/TechStack.ts
+++ b/client/src/types/TechStack.ts
@@ -1,4 +1,4 @@
 export interface TechStack {
-  tech_stack_id: number;
+  id: number;
   name: string;
 }

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,0 +1,3 @@
+export type { Category } from './Category';
+export type { BubbleModalProfileItem } from './Modal';
+export type { TechStack } from './TechStack';


### PR DESCRIPTION
## 관련 이슈

- closes #12 

## 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message 발생 유/무
- [x] Coding Convention 준수 유/무

## 작업 요약
> 작업 내역 요약
- 카테고리박스 필터링 부분 구현
- 클릭된 카테고리 전역 store에 저장시켰습니다. (selectedCategory)

## Preview

> 선택 사항

## PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
> 백로그에 없지만 필요하여 구현한 기능 

- types 폴더를 추상화 시켜놨습니다.
  - 하시던대로 types에 파일을 만드시고 types/index.ts에서 관리하시면 됩니다. 
- MainPage에서 그룹 카테고리 클릭할  때 라우팅 url 수정 했습니다!
`/groups` => `/recruit/group`

