### PR TITLE
[FE]모집페이지(그룹 목록) - 레이아웃 잡기

### DIFF
--- a/client/src/components/GroupCard/GroupApplyButton/index.tsx
+++ b/client/src/components/GroupCard/GroupApplyButton/index.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 function GroupApplyButton(): JSX.Element {
-  return <Container></Container>;
+  return <ApplyButton>보기</ApplyButton>;
 }
 
-const Container = styled.div`
+const ApplyButton = styled.button`
   display: flex;
+  padding: 10px;
+  margin-left: auto;
+  outline: none;
+  border: none;
+  cursor: pointer;
 `;
 
 export default GroupApplyButton;

--- a/client/src/components/GroupCard/GroupApplyButton/index.tsx
+++ b/client/src/components/GroupCard/GroupApplyButton/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+function GroupApplyButton(): JSX.Element {
+  return <Container></Container>;
+}
+
+const Container = styled.div`
+  display: flex;
+`;
+
+export default GroupApplyButton;

--- a/client/src/components/GroupCard/GroupCardHeader/index.tsx
+++ b/client/src/components/GroupCard/GroupCardHeader/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 function GroupCardHeader({ name, maxUserCnt, curUserCnt }: Props): JSX.Element {
   return (
     <Container>
-      <h2>{name}</h2>
+      <GroupName>{name}</GroupName>
       <UserCntStatus>
         {curUserCnt}/{maxUserCnt}
       </UserCntStatus>
@@ -20,9 +20,13 @@ function GroupCardHeader({ name, maxUserCnt, curUserCnt }: Props): JSX.Element {
 
 const Container = styled.div`
   display: flex;
-  width: 100%;
+  margin: 10px;
   justify-content: space-between;
   align-items: center;
+`;
+
+const GroupName = styled.h2`
+  color: ${(props) => props.theme.Primary};
 `;
 
 const UserCntStatus = styled.div`

--- a/client/src/components/GroupCard/GroupCardHeader/index.tsx
+++ b/client/src/components/GroupCard/GroupCardHeader/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+function GroupCardHeader(): JSX.Element {
+  return <Container></Container>;
+}
+
+const Container = styled.div`
+  display: flex;
+`;
+
+export default GroupCardHeader;

--- a/client/src/components/GroupCard/GroupCardHeader/index.tsx
+++ b/client/src/components/GroupCard/GroupCardHeader/index.tsx
@@ -1,12 +1,33 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-function GroupCardHeader(): JSX.Element {
-  return <Container></Container>;
+interface Props {
+  name: string | null;
+  maxUserCnt: number | null;
+  curUserCnt: number | null;
+}
+
+function GroupCardHeader({ name, maxUserCnt, curUserCnt }: Props): JSX.Element {
+  return (
+    <Container>
+      <h2>{name}</h2>
+      <UserCntStatus>
+        {curUserCnt}/{maxUserCnt}
+      </UserCntStatus>
+    </Container>
+  );
 }
 
 const Container = styled.div`
   display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const UserCntStatus = styled.div`
+  display: flex;
+  color: ${(props) => props.theme.Gray4};
 `;
 
 export default GroupCardHeader;

--- a/client/src/components/GroupCard/GroupCardStatus/GroupOwnerStatus.tsx
+++ b/client/src/components/GroupCard/GroupCardStatus/GroupOwnerStatus.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+
+interface Props {
+  ownerId: number;
+}
+
+function GroupOwnerStatus({ ownerId }: Props): JSX.Element {
+  const [groupOwner, setGroupOwner] = useState<string>('홍길동');
+  const [groupOwnerFeverStack, setGroupOwnerFeverStack] = useState<number>(0);
+
+  return (
+    <Container>
+      <GroupOwnerName>{groupOwner}</GroupOwnerName>
+      <GroupOnwerFeverStack>{groupOwnerFeverStack}</GroupOnwerFeverStack>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  margin: 10px;
+  justify-content: space-between;
+`;
+
+const GroupOwnerName = styled.h4`
+  display: flex;
+`;
+
+const GroupOnwerFeverStack = styled.h4`
+  display: flex;
+`;
+
+export default GroupOwnerStatus;

--- a/client/src/components/GroupCard/GroupCardStatus/GroupStatusInfo.tsx
+++ b/client/src/components/GroupCard/GroupCardStatus/GroupStatusInfo.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+interface Props {
+  id: number;
+  intro: string | null;
+  startAt: Date | null;
+  endAt: Date | null;
+}
+
+function GroupStatusInfo({ id, intro, startAt, endAt }: Props): JSX.Element {
+  const getGroupTechStackList = () => {};
+  return (
+    <Container>
+      <GroupIntro>{intro}</GroupIntro>
+      <GroupDate>
+        {startAt?.toLocaleDateString()} ~ {endAt?.toLocaleDateString()}
+      </GroupDate>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 50px;
+  padding: 10px;
+  justify-content: space-between;
+`;
+
+const GroupIntro = styled.h5`
+  color: ${(props) => props.theme.Gray4};
+`;
+
+const GroupDate = styled.h6``;
+
+export default GroupStatusInfo;

--- a/client/src/components/GroupCard/GroupCardStatus/GroupStatusInfo.tsx
+++ b/client/src/components/GroupCard/GroupCardStatus/GroupStatusInfo.tsx
@@ -9,7 +9,10 @@ interface Props {
 }
 
 function GroupStatusInfo({ id, intro, startAt, endAt }: Props): JSX.Element {
-  const getGroupTechStackList = () => {};
+  const getGroupTechStackList = () => {
+    // id를 이용해 가져오기
+    id;
+  };
   return (
     <Container>
       <GroupIntro>{intro}</GroupIntro>

--- a/client/src/components/GroupCard/GroupCardStatus/index.tsx
+++ b/client/src/components/GroupCard/GroupCardStatus/index.tsx
@@ -1,12 +1,28 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import GroupOwnerStatus from './GroupOwnerStatus';
+import GroupStatusInfo from './GroupStatusInfo';
 
-function GroupCardStatus(): JSX.Element {
-  return <Container></Container>;
+interface Props {
+  id: number;
+  ownerId: number;
+  intro: string | null;
+  startAt: Date | null;
+  endAt: Date | null;
+}
+
+function GroupCardStatus({ id, ownerId, intro, startAt, endAt }: Props): JSX.Element {
+  return (
+    <Container>
+      <GroupOwnerStatus ownerId={ownerId} />
+      <GroupStatusInfo id={id} intro={intro} startAt={startAt} endAt={endAt} />
+    </Container>
+  );
 }
 
 const Container = styled.div`
   display: flex;
+  flex-direction: column;
 `;
 
 export default GroupCardStatus;

--- a/client/src/components/GroupCard/GroupCardStatus/index.tsx
+++ b/client/src/components/GroupCard/GroupCardStatus/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+function GroupCardStatus(): JSX.Element {
+  return <Container></Container>;
+}
+
+const Container = styled.div`
+  display: flex;
+`;
+
+export default GroupCardStatus;

--- a/client/src/components/GroupCard/index.tsx
+++ b/client/src/components/GroupCard/index.tsx
@@ -3,11 +3,25 @@ import styled from '@emotion/styled';
 import GroupCardHeader from './GroupCardHeader';
 import GroupCardStatus from './GroupCardStatus';
 import GroupApplyButton from './GroupApplyButton';
+import { Group, GroupState } from '../../types/Group';
+const dummyData: Group = {
+  id: 1,
+  mentorId: 1010,
+  ownerId: 2020,
+  name: 'REACT',
+  maxUserCnt: 5,
+  curUserCnt: 2,
+  intro: '',
+  startAt: new Date(),
+  endAt: new Date(),
+  status: GroupState.DOING,
+};
 
 function GroupCard(): JSX.Element {
+  const { name, maxUserCnt, curUserCnt } = dummyData;
   return (
     <Card>
-      <GroupCardHeader />
+      <GroupCardHeader name={name} maxUserCnt={maxUserCnt} curUserCnt={curUserCnt} />
       <GroupCardStatus />
       <GroupApplyButton />
     </Card>
@@ -16,6 +30,10 @@ function GroupCard(): JSX.Element {
 
 const Card = styled.div`
   display: flex;
+  margin: 10px;
+  padding: 10px;
+  box-shadow: inset 0px 0px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 10px 10px 10px 10px;
 `;
 
 export default GroupCard;

--- a/client/src/components/GroupCard/index.tsx
+++ b/client/src/components/GroupCard/index.tsx
@@ -18,11 +18,11 @@ const dummyData: Group = {
 };
 
 function GroupCard(): JSX.Element {
-  const { name, maxUserCnt, curUserCnt } = dummyData;
+  const { name, maxUserCnt, curUserCnt, ownerId, intro, startAt, endAt } = dummyData;
   return (
     <Card>
       <GroupCardHeader name={name} maxUserCnt={maxUserCnt} curUserCnt={curUserCnt} />
-      <GroupCardStatus />
+      <GroupCardStatus ownerId={ownerId} intro={intro} startAt={startAt} endAt={endAt} />
       <GroupApplyButton />
     </Card>
   );
@@ -30,6 +30,7 @@ function GroupCard(): JSX.Element {
 
 const Card = styled.div`
   display: flex;
+  flex-direction: column;
   margin: 10px;
   padding: 10px;
   box-shadow: inset 0px 0px 4px rgba(0, 0, 0, 0.25);

--- a/client/src/components/GroupCard/index.tsx
+++ b/client/src/components/GroupCard/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import GroupCardHeader from './GroupCardHeader';
+import GroupCardStatus from './GroupCardStatus';
+import GroupApplyButton from './GroupApplyButton';
+
+function GroupCard(): JSX.Element {
+  return (
+    <Card>
+      <GroupCardHeader />
+      <GroupCardStatus />
+      <GroupApplyButton />
+    </Card>
+  );
+}
+
+const Card = styled.div`
+  display: flex;
+`;
+
+export default GroupCard;

--- a/client/src/components/GroupCard/index.tsx
+++ b/client/src/components/GroupCard/index.tsx
@@ -11,18 +11,18 @@ const dummyData: Group = {
   name: 'REACT',
   maxUserCnt: 5,
   curUserCnt: 2,
-  intro: '',
+  intro: '안녕하세요 어서오세요',
   startAt: new Date(),
   endAt: new Date(),
   status: GroupState.DOING,
 };
 
 function GroupCard(): JSX.Element {
-  const { name, maxUserCnt, curUserCnt, ownerId, intro, startAt, endAt } = dummyData;
+  const { id, name, maxUserCnt, curUserCnt, ownerId, intro, startAt, endAt } = dummyData;
   return (
     <Card>
       <GroupCardHeader name={name} maxUserCnt={maxUserCnt} curUserCnt={curUserCnt} />
-      <GroupCardStatus ownerId={ownerId} intro={intro} startAt={startAt} endAt={endAt} />
+      <GroupCardStatus id={id} ownerId={ownerId} intro={intro} startAt={startAt} endAt={endAt} />
       <GroupApplyButton />
     </Card>
   );

--- a/client/src/pages/GroupRecruitPage/index.tsx
+++ b/client/src/pages/GroupRecruitPage/index.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import SearchFilter from '../../components/SearchFilter';
+import GroupCard from '../../components/GroupCard';
 
 function GroupRecruitPage(): JSX.Element {
   return (
     <Container>
       <SearchFilter />
+      <GroupCardList>
+        <GroupCard />
+        <GroupCard />
+        <GroupCard />
+      </GroupCardList>
     </Container>
   );
 }
@@ -13,7 +19,15 @@ function GroupRecruitPage(): JSX.Element {
 const Container = styled.div`
   display: flex;
   justify-content: center;
+  flex-direction: column;
   margin: 20px;
 `;
 
+const GroupCardList = styled.div`
+  display: grid;
+  margin: 10px auto;
+
+  grid-template-columns: repeat(4, minmax(250px, 2fr));
+  grid-template-rows: repeat(auo-fit, minmax(100px, 2fr));
+`;
 export default GroupRecruitPage;

--- a/client/src/types/Group.ts
+++ b/client/src/types/Group.ts
@@ -1,0 +1,18 @@
+export enum GroupState {
+  READY = 'READY',
+  DOING = 'DOING',
+  END = 'END',
+}
+
+export interface Group {
+  id: number;
+  mentorId: number;
+  ownerId: number;
+  name: string | null;
+  maxUserCnt: number | null;
+  curUserCnt: number | null;
+  intro: string | null;
+  startAt: Date | null;
+  endAt: Date | null;
+  status: GroupState;
+}


### PR DESCRIPTION
## 관련 이슈

- closes #55  

## 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message 발생 유/무
- [x] Coding Convention 준수 유/무

## 작업 요약
> 작업 내역 요약

- 모집페이지 레이아웃 잡기

## Preview

> 선택 사항

![image](https://user-images.githubusercontent.com/48426909/140571936-d1338d77-0d8f-4740-af95-41fde25d6d44.png)

## PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
> 백로그에 없지만 필요하여 구현한 기능 

- 프론트엔드 types/Group 파일 만들었습니다! (Group 테이블 전체적인 설정을 가져왔습니다)
- 일단 대략적인 카드 디자인만 잡아놨습니다... 더 추가할 부분이나 수정할 부분들은 추후에 개발 진행하면서 수정하겠습니다~!! (기술스택부분 등)
---
### 추가적으로 고민했던 부분
- 지금 카드 형태로 재사용할거기 때문에 내부 값들을 다 props 드릴링으로 구현을 했습니다.
- 그랬더니 조금 지저분해지는거 같아서 이런 재사용 단위는 따로 임시 store로 만들어 하는게 좋을까요? 아니면 그냥 이렇게 드릴링으로 하는게 좋을까요??