### PR TITLE
[BE]헤더 - 사용자 전역 정보 API

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { Header } from './components';
 import Router from '@core/Router';
-import { useSlientRefresh } from '@hooks';
+import { useSilentRefresh } from '@hooks';
 
 function App(): JSX.Element {
-  useSlientRefresh();
+  useSilentRefresh();
   return (
     <BrowserRouter>
       <Header />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { Header } from './components';
 import Router from '@core/Router';
+import { useSlientRefresh } from '@hooks';
 
 function App(): JSX.Element {
+  useSlientRefresh();
   return (
     <BrowserRouter>
       <Header />

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,7 +1,7 @@
 import { requests } from './index';
 import { ResponseGithubUserData } from '../types';
-export const getSlientRefresh = (): Promise<ResponseGithubUserData> =>
-  requests.get(`/auth/slient-refresh`);
+export const getSilentRefresh = (): Promise<ResponseGithubUserData> =>
+  requests.get(`/auth/silent-refresh`);
 export const getAccessToken = (code: string): Promise<ResponseGithubUserData> =>
   requests.get(`/auth/token?code=${code}`);
 export const getLogout = (): Promise<null> => requests.get(`/auth/logout`);

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,5 +1,7 @@
 import { requests } from './index';
 import { ResponseGithubUserData } from '../types';
+export const getSlientRefresh = (): Promise<ResponseGithubUserData> =>
+  requests.get(`/auth/slient-refresh`);
 export const getAccessToken = (code: string): Promise<ResponseGithubUserData> =>
   requests.get(`/auth/token?code=${code}`);
 export const getLogout = (): Promise<null> => requests.get(`/auth/logout`);

--- a/client/src/hooks/auth.ts
+++ b/client/src/hooks/auth.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { getSlientRefresh } from '@api/auth';
+import { useAppDispatch } from '@hooks';
+import { setUser } from '@store/slices/userSlice';
+
+export function useSlientRefresh(): void {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    (async () => {
+      const userData = await getSlientRefresh();
+      if (!userData) return;
+      const { githubId: id, name, avatarUrl: image } = userData;
+      dispatch(setUser({ id, name, image }));
+    })();
+  }, []);
+}

--- a/client/src/hooks/auth.ts
+++ b/client/src/hooks/auth.ts
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
-import { getSlientRefresh } from '@api/auth';
+import { getSilentRefresh } from '@api/auth';
 import { useAppDispatch } from '@hooks';
 import { setUser } from '@store/slices/userSlice';
 
-export function useSlientRefresh(): void {
+export function useSilentRefresh(): void {
   const dispatch = useAppDispatch();
   useEffect(() => {
     (async () => {
-      const userData = await getSlientRefresh();
+      const userData = await getSilentRefresh();
       if (!userData) return;
       const { githubId: id, name, avatarUrl: image } = userData;
       dispatch(setUser({ id, name, image }));

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -1,2 +1,2 @@
 export { useAppDispatch, useAppSelector } from './store';
-export { useSlientRefresh } from './auth';
+export { useSilentRefresh } from './auth';

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useAppDispatch, useAppSelector } from './store';
+export { useSlientRefresh } from './auth';

--- a/server/src/domains/auth/api/AuthContorller.ts
+++ b/server/src/domains/auth/api/AuthContorller.ts
@@ -12,8 +12,17 @@ import { AuthService } from '../service/AuthService';
 @Service()
 @Controller('/auth')
 export class AuthController {
-  @Inject()
-  private readonly authService: AuthService;
+  constructor(
+    @Inject()
+    private readonly authService: AuthService,
+  ) {}
+
+  @Get('/slient-refresh')
+  @OnUndefined(203)
+  async getAuthentification(@SessionParam('githubId') githubId: string) {
+    if (!githubId) return;
+    return await this.authService.getUserProfile(githubId);
+  }
 
   @Get('/token')
   async getGithubAccessToken(

--- a/server/src/domains/auth/api/AuthContorller.ts
+++ b/server/src/domains/auth/api/AuthContorller.ts
@@ -17,7 +17,7 @@ export class AuthController {
     private readonly authService: AuthService,
   ) {}
 
-  @Get('/slient-refresh')
+  @Get('/silent-refresh')
   @OnUndefined(203)
   async getAuthentification(@SessionParam('githubId') githubId: string) {
     if (!githubId) return;

--- a/server/src/domains/auth/service/AuthService.ts
+++ b/server/src/domains/auth/service/AuthService.ts
@@ -2,13 +2,18 @@ import { Service } from 'typedi';
 import { InjectRepository } from 'typeorm-typedi-extensions';
 import axios from 'axios';
 import { UserRepository } from '../../user/repository/UserRepository';
+import { ProfileRepository } from '../../user/repository/ProfileRepository';
 import { GithubUserDto } from '../Dto/AuthDto';
+import { UserDto } from '../../user/dto/UserDto';
+import { destructObject } from '../../../utils/Object';
 
 @Service()
 export class AuthService {
   constructor(
     @InjectRepository()
     private readonly userRepository: UserRepository,
+    @InjectRepository()
+    private readonly profileRepository: ProfileRepository,
   ) {}
 
   public async getGithubAccessToken(code: string) {
@@ -42,12 +47,15 @@ export class AuthService {
     return { githubId, name, avatarUrl };
   }
 
-  public async findOrInsertUser(user: GithubUserDto): Promise<GithubUserDto> {
-    const { githubId, name, avatarUrl } = user;
-    let userData = await this.userRepository.findOneById(githubId);
-    if (!userData) 
-      userData= await this.userRepository.insertUser(user);
-    
-    return userData as GithubUserDto;
+  public async findOrInsertUser(user: GithubUserDto): Promise<UserDto> {
+    const { githubId } = user;
+    let profileData = await this.profileRepository.findOneByUserId(githubId);
+    if (!profileData) {
+      const userData = await this.userRepository.insertUser(user);
+      profileData = await this.profileRepository.insertProfile(userData);
+    }
+
+    const userData = destructObject(profileData);
+    return userData as UserDto;
   }
 }

--- a/server/src/domains/auth/service/AuthService.ts
+++ b/server/src/domains/auth/service/AuthService.ts
@@ -58,4 +58,9 @@ export class AuthService {
     const userData = destructObject(profileData);
     return userData as UserDto;
   }
+
+  public async getUserProfile(id: string): Promise<UserDto> {
+    let userData = await this.profileRepository.findOneByUserId(id);
+    return destructObject(userData) as UserDto;
+  }
 }

--- a/server/src/domains/user/dto/ProfileDto.ts
+++ b/server/src/domains/user/dto/ProfileDto.ts
@@ -1,0 +1,7 @@
+import { User } from '../models/User';
+export interface ProfileDto {
+  userId: User;
+  feverStack: number;
+  shareStack: number;
+  introduction: string;
+}

--- a/server/src/domains/user/dto/ProfileDto.ts
+++ b/server/src/domains/user/dto/ProfileDto.ts
@@ -1,6 +1,5 @@
-import { User } from '../models/User';
 export interface ProfileDto {
-  userId: User;
+  userId: int;
   feverStack: number;
   shareStack: number;
   introduction: string;

--- a/server/src/domains/user/dto/UserDto.ts
+++ b/server/src/domains/user/dto/UserDto.ts
@@ -1,0 +1,8 @@
+export interface UserDto {
+  id: number;
+  githubId: string;
+  name: string;
+  avatarUrl: string;
+  feverStack: number;
+  shareStack: number;
+}

--- a/server/src/domains/user/models/Profile.ts
+++ b/server/src/domains/user/models/Profile.ts
@@ -7,9 +7,8 @@ export class Profile {
   @PrimaryGeneratedColumn({ name: 'profile_id' })
   id: number;
 
-  @OneToOne(() => User)
-  @JoinColumn({ name: 'user_id' })
-  userId: User;
+  @Column('int', { name: 'user_id' })
+  userId: number;
 
   @Column('float', { name: 'fever_stack', precision: 12 })
   feverStack: number;
@@ -19,6 +18,10 @@ export class Profile {
 
   @Column('varchar', { name: 'intro', nullable: true, length: 500 })
   intro: string | null;
+
+  @OneToOne(() => User, (user) => user.profile)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
 
   @OneToMany(() => UsingTechStack, (usingTechStack) => usingTechStack.profile)
   usingTechStacks: UsingTechStack[];

--- a/server/src/domains/user/models/User.ts
+++ b/server/src/domains/user/models/User.ts
@@ -27,7 +27,7 @@ export class User {
   @OneToMany(() => GroupEnrollment, (groupEnrollment) => groupEnrollment.user)
   groupEnrollments: GroupEnrollment[];
 
-  @OneToOne(() => Profile)
+  @OneToOne(() => Profile, (profile) => profile.user)
   profile: Profile;
 
   @OneToMany(() => Alarm, (alarm) => alarm.recieverId)

--- a/server/src/domains/user/repository/ProfileRepository.ts
+++ b/server/src/domains/user/repository/ProfileRepository.ts
@@ -1,0 +1,35 @@
+import { Profile } from '../models/Profile';
+import { User } from '../models/User';
+import { Service } from 'typedi';
+import { Repository, EntityRepository } from 'typeorm';
+import { ProfileDto } from '../dto/ProfileDto';
+
+@Service()
+@EntityRepository(Profile)
+export class ProfileRepository extends Repository<Profile> {
+  public async insertProfile(user: User) {
+    const defaultProfile: ProfileDto = {
+      userId: user,
+      feverStack: 36.5,
+      shareStack: 0,
+      introduction: '',
+    };
+    await this.insert(defaultProfile);
+    return await this.findOneByUserId(user.githubId);
+  }
+  public async findOneByUserId(id: string) {
+    const profile = await this.createQueryBuilder('profile')
+      .select([
+        'user.id',
+        'user.githubId',
+        'user.name',
+        'user.avatarUrl',
+        'profile.feverStack',
+        'profile.shareStack',
+      ])
+      .leftJoin('profile.userId', 'user')
+      .getOne();
+
+    return profile;
+  }
+}

--- a/server/src/domains/user/repository/ProfileRepository.ts
+++ b/server/src/domains/user/repository/ProfileRepository.ts
@@ -27,7 +27,7 @@ export class ProfileRepository extends Repository<Profile> {
         'profile.feverStack',
         'profile.shareStack',
       ])
-      .leftJoin('profile.userId', 'user')
+      .leftJoin('profile.user', 'user')
       .getOne();
 
     return profile;

--- a/server/src/domains/user/repository/UserRepository.ts
+++ b/server/src/domains/user/repository/UserRepository.ts
@@ -1,4 +1,4 @@
-import { User } from '../../user/models/User';
+import { User } from '../models/User';
 import { Service } from 'typedi';
 import { Repository, EntityRepository } from 'typeorm';
 import { GithubUserDto } from '../../auth/dto/AuthDto';

--- a/server/src/utils/Object.ts
+++ b/server/src/utils/Object.ts
@@ -1,0 +1,8 @@
+export function destructObject(object: any): object {
+  let obj = {};
+  for (let key in object) {
+    if (typeof object[key] === 'object') obj = { ...obj, ...destructObject(object[key]) };
+    else obj = { ...obj, [key]: object[key] };
+  }
+  return obj;
+}

--- a/server/src/utils/Object.ts
+++ b/server/src/utils/Object.ts
@@ -1,6 +1,6 @@
 export function destructObject(object: any): object {
   let obj = {};
-  for (let key in object) {
+  for (const key in object) {
     if (typeof object[key] === 'object') obj = { ...obj, ...destructObject(object[key]) };
     else obj = { ...obj, [key]: object[key] };
   }


### PR DESCRIPTION
## 관련 이슈

- closes #29 

## 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [ ] Warning Message 발생 유/무
- [x] Coding Convention 준수 유/무

## 작업 요약
> 작업 내역 요약
- slient-refresh 동작 추가 (세션이 있으면 자동 로그인)
- 유저 정보 API의 body 내용 추가 (열정, 나눔 지수)

## PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
> 백로그에 없지만 필요하여 구현한 기능 

- typeorm의 쿼리 결과의 객체를 사용하기 좋게 분해하는 destructObejct 함수를 추가했습니다.
- slient-refresh 동작을 커스텀훅으로 만들어 추가했습니다.

