### PR TITLE
[BE]그룹 생성 페이지 - 그룹 생성 페이지 API

### DIFF
--- a/client/src/api/group.ts
+++ b/client/src/api/group.ts
@@ -1,4 +1,8 @@
 import { GroupResponse } from '@types';
+import { GroupCreateInterface } from '../types/ServerData';
 import { requests } from './index';
 
 export const getAllGroupList = (): Promise<GroupResponse> => requests.get(`/group`);
+
+export const postGroupCreate = <T>(groupData: GroupCreateInterface): Promise<T> =>
+  requests.post('/group/create', groupData);

--- a/client/src/api/group.ts
+++ b/client/src/api/group.ts
@@ -1,5 +1,4 @@
-import { GroupResponse } from '@types';
-import { GroupCreateInterface } from '@types';
+import { GroupResponse, GroupCreateInterface } from '@types';
 import { requests } from './index';
 
 export const getAllGroupList = (): Promise<GroupResponse> => requests.get(`/group`);

--- a/client/src/api/group.ts
+++ b/client/src/api/group.ts
@@ -1,5 +1,5 @@
 import { GroupResponse } from '@types';
-import { GroupCreateInterface } from '../types/ServerData';
+import { GroupCreateInterface } from '@types';
 import { requests } from './index';
 
 export const getAllGroupList = (): Promise<GroupResponse> => requests.get(`/group`);

--- a/client/src/core/Router/index.tsx
+++ b/client/src/core/Router/index.tsx
@@ -11,6 +11,7 @@ import ChatListPage from '@pages/ChatListPage';
 import ChatPage from '@pages/ChatPage';
 import ProfilePage from '@pages/ProfilePage';
 import { Auth as AuthCallback } from '@components';
+import GroupCreatePage from '../../pages/GroupCreatePage';
 
 function Router(): JSX.Element {
   return (
@@ -21,6 +22,7 @@ function Router(): JSX.Element {
       <Route path="/groups" component={GroupsPage} exact />
       <Route path="/group/status" component={GroupStatusPage} />
       <Route path="/group/owner" component={GroupOwnerPage} />
+      <Route path="/group/create" component={GroupCreatePage} />
       <Route path="/group/evaluate" component={EvaluateGroupPage} />
       <Route path="/chat/list" component={ChatListPage} />
       <Route path="/chat" component={ChatPage} />

--- a/client/src/pages/GroupCreatePage/CategoryInput/CategoryItem.tsx
+++ b/client/src/pages/GroupCreatePage/CategoryInput/CategoryItem.tsx
@@ -4,35 +4,42 @@ import styled from '@emotion/styled';
 interface ItemProp {
   key: number;
   category: string;
+  image: string;
   clicked: boolean;
   handleCategoryClick: () => void;
 }
 
-function CategoryItem({ category, clicked, handleCategoryClick }: ItemProp): JSX.Element {
+function CategoryItem({ category, clicked, image, handleCategoryClick }: ItemProp): JSX.Element {
   return (
     <div onClick={handleCategoryClick}>
-      {clicked ? <ClickedItem /> : <Item />}
+      {clicked ? (
+        <ClickedItem>
+          <CategoryIcon src={image} />
+        </ClickedItem>
+      ) : (
+        <UnClickedItem>
+          <CategoryIcon src={image} />
+        </UnClickedItem>
+      )}
       <ItemName>{category}</ItemName>
     </div>
   );
 }
-
-const ClickedItem = styled.div`
-  width: 60px;
-  height: 60px;
-  margin: auto;
-  border-radius: 10px;
-  box-shadow: inset 5px 5px 10px #8f8f8f, inset -5px -5px 10px #ffffff;
-`;
 
 const Item = styled.div`
   width: 60px;
   height: 60px;
   margin: auto;
   border-radius: 10px;
-  box-shadow: 5px 5px 10px #8f8f8f, -5px -5px 10px #ffffff;
 `;
 
+const ClickedItem = styled(Item)`
+  box-shadow: inset 5px 5px 10px #8f8f8f, inset -5px -5px 10px #ffffff;
+`;
+
+const UnClickedItem = styled(Item)`
+  box-shadow: 5px 5px 10px #8f8f8f, -5px -5px 10px #ffffff;
+`;
 const ItemName = styled.p`
   width: 80px;
   margin-top: 10px;
@@ -40,6 +47,13 @@ const ItemName = styled.p`
   color: ${(props) => props.theme.Gray3};
   font-weight: bold;
   text-align: center;
+`;
+
+const CategoryIcon = styled.img`
+  width: 50px;
+  height: 50px;
+  margin-top: 5px;
+  margin-bottom: 8px;
 `;
 
 export default CategoryItem;

--- a/client/src/pages/GroupCreatePage/CategoryInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/CategoryInput/index.tsx
@@ -1,21 +1,17 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '@store/rootReducer';
-import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '@store/slices/createGroupData';
+import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDataSlice';
 import { Category } from '@types';
 import CategoryItem from './CategoryItem';
+import { useAppDispatch, useAppSelector } from '@hooks';
 
 interface Props {
   categorys: Category[];
 }
 
 function CategoryInput({ categorys }: Props): JSX.Element {
-  const { category: SelectedCategory } = useSelector<ReducerType, GroupData>(
-    (state) => state.createGroupData,
-  );
-  const dispatch = useDispatch();
+  const { category: SelectedCategory } = useAppSelector(groupCreateDataState)
+  const dispatch = useAppDispatch();
 
   const getCategoryItemElements = () => {
     return categorys.map((category) => (

--- a/client/src/pages/GroupCreatePage/CategoryInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/CategoryInput/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '../../../store/rootReducer';
+import { ReducerType } from '@store/rootReducer';
 import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '../../../store/slices/createGroupData';
-import { Category } from '../../../types';
+import { setGroupData } from '@store/slices/createGroupData';
+import { Category } from '@types';
 import CategoryItem from './CategoryItem';
 
 interface Props {

--- a/client/src/pages/GroupCreatePage/CategoryInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/CategoryInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch, useSelector } from 'react-redux';
 import { ReducerType } from '../../../store/rootReducer';
@@ -6,21 +6,16 @@ import { GroupData } from '../../../types/CreateGroup';
 import { setGroupData } from '../../../store/slices/createGroupData';
 import { Category } from '../../../types';
 import CategoryItem from './CategoryItem';
-import { getCategories } from '../../../api/category';
 
-function CategoryInput(): JSX.Element {
-  const [categorys, setCategorys] = useState<Category[]>([]);
-  const { category: SelectedCategory } = useSelector<ReducerType, GroupData>((state) => state.createGroupData);
+interface Props {
+  categorys: Category[];
+}
+
+function CategoryInput({ categorys }: Props): JSX.Element {
+  const { category: SelectedCategory } = useSelector<ReducerType, GroupData>(
+    (state) => state.createGroupData,
+  );
   const dispatch = useDispatch();
-
-  useEffect(() =>{
-    const fetchCategoryList = async() => {
-      const newCategorys = await getCategories();
-      setCategorys(newCategorys);
-    }
-
-    fetchCategoryList();
-  },[]);
 
   const getCategoryItemElements = () => {
     return categorys.map((category) => (

--- a/client/src/pages/GroupCreatePage/CategoryInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/CategoryInput/index.tsx
@@ -1,40 +1,42 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import CategoryItem from './CategoryItem';
 import { useDispatch, useSelector } from 'react-redux';
 import { ReducerType } from '../../../store/rootReducer';
 import { GroupData } from '../../../types/CreateGroup';
 import { setGroupData } from '../../../store/slices/createGroupData';
-
-const categoryList: string[] = [
-  '대외활동',
-  '공모전',
-  '스터디',
-  '동아리',
-  '면접/인터뷰',
-  '토이프로젝트',
-  '구인/구직',
-  '기타',
-];
+import { Category } from '../../../types';
+import CategoryItem from './CategoryItem';
+import { getCategories } from '../../../api/category';
 
 function CategoryInput(): JSX.Element {
-  const { category } = useSelector<ReducerType, GroupData>((state) => state.createGroupData);
+  const [categorys, setCategorys] = useState<Category[]>([]);
+  const { category: SelectedCategory } = useSelector<ReducerType, GroupData>((state) => state.createGroupData);
   const dispatch = useDispatch();
 
-  const getList = () => {
-    return categoryList.map((categoryName, idx) => (
+  useEffect(() =>{
+    const fetchCategoryList = async() => {
+      const newCategorys = await getCategories();
+      setCategorys(newCategorys);
+    }
+
+    fetchCategoryList();
+  },[]);
+
+  const getCategoryItemElements = () => {
+    return categorys.map((category) => (
       <CategoryItem
-        key={idx}
-        category={categoryName}
-        clicked={categoryName === category}
-        handleCategoryClick={() => dispatch(setGroupData({ category: categoryName }))}
+        key={category.id}
+        category={category.name}
+        image={category.imageUrl}
+        clicked={category.name === SelectedCategory}
+        handleCategoryClick={() => dispatch(setGroupData({ category: category.name }))}
       />
     ));
   };
   return (
     <>
       <Title>카테고리를 선택해주세요.</Title>
-      <CategoryWrapper>{getList()}</CategoryWrapper>
+      <CategoryWrapper>{getCategoryItemElements()}</CategoryWrapper>
     </>
   );
 }

--- a/client/src/pages/GroupCreatePage/DateInput/AntDatePicker.tsx
+++ b/client/src/pages/GroupCreatePage/DateInput/AntDatePicker.tsx
@@ -6,9 +6,9 @@ import { RangeValue } from 'rc-picker/lib/interface';
 const { RangePicker } = DatePicker;
 import 'antd/es/date-picker/style/css';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '../../../store/rootReducer';
+import { ReducerType } from '@store/rootReducer';
 import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '../../../store/slices/createGroupData';
+import { setGroupData } from '@store/slices/createGroupData';
 
 function AntDatePicker(): JSX.Element {
   const { startDate, endDate } = useSelector<ReducerType, GroupData>(

--- a/client/src/pages/GroupCreatePage/DateInput/AntDatePicker.tsx
+++ b/client/src/pages/GroupCreatePage/DateInput/AntDatePicker.tsx
@@ -5,16 +5,12 @@ import styled from '@emotion/styled';
 import { RangeValue } from 'rc-picker/lib/interface';
 const { RangePicker } = DatePicker;
 import 'antd/es/date-picker/style/css';
-import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '@store/rootReducer';
-import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '@store/slices/createGroupData';
+import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDataSlice';
+import { useAppDispatch, useAppSelector } from '@hooks';
 
 function AntDatePicker(): JSX.Element {
-  const { startDate, endDate } = useSelector<ReducerType, GroupData>(
-    (state) => state.createGroupData,
-  );
-  const dispatch = useDispatch();
+  const { startDate, endDate } = useAppSelector(groupCreateDataState);
+  const dispatch = useAppDispatch();
 
   const checkDate = (current: moment.Moment) => {
     const now = new Date();

--- a/client/src/pages/GroupCreatePage/DateInput/AntDatePicker.tsx
+++ b/client/src/pages/GroupCreatePage/DateInput/AntDatePicker.tsx
@@ -9,7 +9,7 @@ import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDat
 import { useAppDispatch, useAppSelector } from '@hooks';
 
 function AntDatePicker(): JSX.Element {
-  const { startDate, endDate } = useAppSelector(groupCreateDataState);
+  const { startAt, endAt } = useAppSelector(groupCreateDataState);
   const dispatch = useAppDispatch();
 
   const checkDate = (current: moment.Moment) => {
@@ -25,7 +25,7 @@ function AntDatePicker(): JSX.Element {
     formatString: [string, string],
   ) => {
     const [newStartDate, newEndDate] = formatString;
-    dispatch(setGroupData({ startDate: newStartDate, endDate: newEndDate }));
+    dispatch(setGroupData({ startAt: newStartDate, endAt: newEndDate }));
   };
   return (
     <CustomPicker
@@ -33,10 +33,7 @@ function AntDatePicker(): JSX.Element {
       size="large"
       disabledDate={checkDate}
       onChange={handleCalendarChange}
-      defaultValue={[
-        startDate !== '' ? moment(startDate) : null,
-        endDate !== '' ? moment(endDate) : null,
-      ]}
+      defaultValue={[startAt !== '' ? moment(startAt) : null, endAt !== '' ? moment(endAt) : null]}
       style={{
         width: '100%',
         textAlign: 'center',

--- a/client/src/pages/GroupCreatePage/GroupInfoInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/GroupInfoInput/index.tsx
@@ -1,15 +1,11 @@
 import styled from '@emotion/styled';
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '@store/rootReducer';
-import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '@store/slices/createGroupData';
+import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDataSlice';
+import { useAppDispatch, useAppSelector } from '@hooks';
 
 function GroupInfoInput(): JSX.Element {
-  const { groupName, groupInfo } = useSelector<ReducerType, GroupData>(
-    (state) => state.createGroupData,
-  );
-  const dispatch = useDispatch();
+  const { groupName, groupInfo } = useAppSelector(groupCreateDataState);
+  const dispatch = useAppDispatch();
 
   const setGroupName = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(setGroupData({ groupName: e.target.value }));

--- a/client/src/pages/GroupCreatePage/GroupInfoInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/GroupInfoInput/index.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '../../../store/rootReducer';
+import { ReducerType } from '@store/rootReducer';
 import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '../../../store/slices/createGroupData';
+import { setGroupData } from '@store/slices/createGroupData';
 
 function GroupInfoInput(): JSX.Element {
   const { groupName, groupInfo } = useSelector<ReducerType, GroupData>(

--- a/client/src/pages/GroupCreatePage/GroupInfoInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/GroupInfoInput/index.tsx
@@ -4,20 +4,20 @@ import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDat
 import { useAppDispatch, useAppSelector } from '@hooks';
 
 function GroupInfoInput(): JSX.Element {
-  const { groupName, groupInfo } = useAppSelector(groupCreateDataState);
+  const { name, intro } = useAppSelector(groupCreateDataState);
   const dispatch = useAppDispatch();
 
   const setGroupName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch(setGroupData({ groupName: e.target.value }));
+    dispatch(setGroupData({ name: e.target.value }));
   };
 
   const setGroupInfo = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    dispatch(setGroupData({ groupInfo: e.target.value }));
+    dispatch(setGroupData({ intro: e.target.value }));
   };
   return (
     <>
-      <NameText onChange={setGroupName} value={groupName} placeholder="그룹명을 작성해주세요." />
-      <InfoText onChange={setGroupInfo} value={groupInfo} placeholder="그룹소개를 작성해주세요." />
+      <NameText onChange={setGroupName} value={name} placeholder="그룹명을 작성해주세요." />
+      <InfoText onChange={setGroupInfo} value={intro} placeholder="그룹소개를 작성해주세요." />
     </>
   );
 }

--- a/client/src/pages/GroupCreatePage/PersonnelInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/PersonnelInput/index.tsx
@@ -1,13 +1,11 @@
 import styled from '@emotion/styled';
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '@store/rootReducer';
-import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '@store/slices/createGroupData';
+import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDataSlice';
+import { useAppDispatch, useAppSelector } from '@hooks';
 
 function PersonnelInput(): JSX.Element {
-  const { personnelCount } = useSelector<ReducerType, GroupData>((state) => state.createGroupData);
-  const dispatch = useDispatch();
+  const { personnelCount } = useAppSelector(groupCreateDataState);
+  const dispatch = useAppDispatch();
   const onChangeBar = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value);
     dispatch(setGroupData({ personnelCount: value }));

--- a/client/src/pages/GroupCreatePage/PersonnelInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/PersonnelInput/index.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '../../../store/rootReducer';
+import { ReducerType } from '@store/rootReducer';
 import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '../../../store/slices/createGroupData';
+import { setGroupData } from '@store/slices/createGroupData';
 
 function PersonnelInput(): JSX.Element {
   const { personnelCount } = useSelector<ReducerType, GroupData>((state) => state.createGroupData);

--- a/client/src/pages/GroupCreatePage/PersonnelInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/PersonnelInput/index.tsx
@@ -4,18 +4,18 @@ import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDat
 import { useAppDispatch, useAppSelector } from '@hooks';
 
 function PersonnelInput(): JSX.Element {
-  const { personnelCount } = useAppSelector(groupCreateDataState);
+  const { maxUserCnt } = useAppSelector(groupCreateDataState);
   const dispatch = useAppDispatch();
   const onChangeBar = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value);
-    dispatch(setGroupData({ personnelCount: value }));
+    dispatch(setGroupData({ maxUserCnt: value }));
   };
 
   return (
     <>
       <Title>그룹의 정원을 선택해주세요.</Title>
-      <RangeValue>{personnelCount}</RangeValue>
-      <RangeBar type="range" min="1" max="30" onChange={onChangeBar} value={personnelCount} />
+      <RangeValue>{maxUserCnt}</RangeValue>
+      <RangeBar type="range" min="1" max="30" onChange={onChangeBar} value={maxUserCnt} />
     </>
   );
 }

--- a/client/src/pages/GroupCreatePage/TechStackInput/SelectedTechStackList.tsx
+++ b/client/src/pages/GroupCreatePage/TechStackInput/SelectedTechStackList.tsx
@@ -4,19 +4,19 @@ import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDat
 import { useAppDispatch, useAppSelector } from '@hooks';
 
 function SelectedTechStackList(): JSX.Element {
-  const { selectedTechStack } = useAppSelector(groupCreateDataState);
+  const { usingTechStacks } = useAppSelector(groupCreateDataState);
   const dispatch = useAppDispatch();
 
   const handleEraseButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const targetTechStack = e.currentTarget as HTMLButtonElement;
     const nowTechStack = targetTechStack.previousElementSibling?.innerHTML;
-    const newSelectedTechStack = selectedTechStack.filter((techStackName) => {
+    const newSelectedTechStack = usingTechStacks.filter((techStackName) => {
       return techStackName !== nowTechStack;
     });
 
-    dispatch(setGroupData({ selectedTechStack: newSelectedTechStack }));
+    dispatch(setGroupData({ usingTechStacks: newSelectedTechStack }));
   };
-  const selectedTechListElements = selectedTechStack.map((techStackName, idx) => {
+  const selectedTechListElements = usingTechStacks.map((techStackName, idx) => {
     return (
       <SelectItem key={idx}>
         <h4>{techStackName}</h4>

--- a/client/src/pages/GroupCreatePage/TechStackInput/SelectedTechStackList.tsx
+++ b/client/src/pages/GroupCreatePage/TechStackInput/SelectedTechStackList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '../../../store/rootReducer';
+import { ReducerType } from '@store/rootReducer';
 import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '../../../store/slices/createGroupData';
+import { setGroupData } from '@store/slices/createGroupData';
 
 function SelectedTechStackList(): JSX.Element {
   const { selectedTechStack } = useSelector<ReducerType, GroupData>(

--- a/client/src/pages/GroupCreatePage/TechStackInput/SelectedTechStackList.tsx
+++ b/client/src/pages/GroupCreatePage/TechStackInput/SelectedTechStackList.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '@store/rootReducer';
-import { GroupData } from '../../../types/CreateGroup';
-import { setGroupData } from '@store/slices/createGroupData';
+import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDataSlice';
+import { useAppDispatch, useAppSelector } from '@hooks';
 
 function SelectedTechStackList(): JSX.Element {
-  const { selectedTechStack } = useSelector<ReducerType, GroupData>(
-    (state) => state.createGroupData,
-  );
-  const dispatch = useDispatch();
+  const { selectedTechStack } = useAppSelector(groupCreateDataState);
+  const dispatch = useAppDispatch();
 
   const handleEraseButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const targetTechStack = e.currentTarget as HTMLButtonElement;

--- a/client/src/pages/GroupCreatePage/TechStackInput/TechStackList.tsx
+++ b/client/src/pages/GroupCreatePage/TechStackInput/TechStackList.tsx
@@ -1,11 +1,9 @@
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '@store/rootReducer';
-import { setGroupData } from '@store/slices/createGroupData';
-import { GroupData } from '../../../types/CreateGroup';
+import { groupCreateDataState, setGroupData } from '@store/slices/groupCreateDataSlice';
 import { TechStack } from '@types';
+import { useAppDispatch, useAppSelector } from '@hooks';
 
 const MAX_SELECTED_INDEX = 5;
 
@@ -13,10 +11,8 @@ interface Props {
   techStackList: TechStack[];
 }
 function TechStackList({ techStackList }: Props): JSX.Element {
-  const { selectedTechStack } = useSelector<ReducerType, GroupData>(
-    (state) => state.createGroupData,
-  );
-  const dispatch = useDispatch();
+  const { selectedTechStack } = useAppSelector(groupCreateDataState);
+  const dispatch = useAppDispatch();
   const handleTechStackClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const clickedTechStack = e.target as HTMLButtonElement;
     const techStackName = clickedTechStack.innerText;

--- a/client/src/pages/GroupCreatePage/TechStackInput/TechStackList.tsx
+++ b/client/src/pages/GroupCreatePage/TechStackInput/TechStackList.tsx
@@ -11,7 +11,7 @@ interface Props {
   techStackList: TechStack[];
 }
 function TechStackList({ techStackList }: Props): JSX.Element {
-  const { selectedTechStack } = useAppSelector(groupCreateDataState);
+  const { usingTechStacks } = useAppSelector(groupCreateDataState);
   const dispatch = useAppDispatch();
   const handleTechStackClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const clickedTechStack = e.target as HTMLButtonElement;
@@ -20,17 +20,17 @@ function TechStackList({ techStackList }: Props): JSX.Element {
     clickedTechStack.classList.remove('shake');
     clickedTechStack.offsetWidth;
 
-    if (selectedTechStack.length >= MAX_SELECTED_INDEX) {
+    if (usingTechStacks.length >= MAX_SELECTED_INDEX) {
       clickedTechStack.classList.add('shake');
-    } else if (!selectedTechStack.includes(techStackName)) {
-      const newTechStack: string[] = [...selectedTechStack];
+    } else if (!usingTechStacks.includes(techStackName)) {
+      const newTechStack: string[] = [...usingTechStacks];
 
       newTechStack.push(techStackName);
-      dispatch(setGroupData({ selectedTechStack: newTechStack }));
+      dispatch(setGroupData({ usingTechStacks: newTechStack }));
     }
   };
   const techStackElements = techStackList.map((techStack, idx) => {
-    return selectedTechStack.includes(techStack.name) ? (
+    return usingTechStacks.includes(techStack.name) ? (
       <SelectedTechListItem key={idx}>{techStack.name}</SelectedTechListItem>
     ) : (
       <TechListItem key={idx} onClick={handleTechStackClick}>

--- a/client/src/pages/GroupCreatePage/TechStackInput/TechStackList.tsx
+++ b/client/src/pages/GroupCreatePage/TechStackInput/TechStackList.tsx
@@ -2,10 +2,10 @@ import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '../../../store/rootReducer';
-import { setGroupData } from '../../../store/slices/createGroupData';
+import { ReducerType } from '@store/rootReducer';
+import { setGroupData } from '@store/slices/createGroupData';
 import { GroupData } from '../../../types/CreateGroup';
-import { TechStack } from '../../../types/TechStack';
+import { TechStack } from '@types';
 
 const MAX_SELECTED_INDEX = 5;
 

--- a/client/src/pages/GroupCreatePage/TechStackInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/TechStackInput/index.tsx
@@ -1,26 +1,20 @@
 import React, { useEffect, useState } from 'react';
-import { getTechStackList } from '../../../api/techStack';
 import { TechStack } from '../../../types/TechStack';
 import SearchBar from './SearchBar';
 import SelectedTechStackList from './SelectedTechStackList';
 import TechStackList from './TechStackList';
 
-function TechStackInput(): JSX.Element {
-  const [baseTechStackList, setBaseTechStackList] = useState<TechStack[]>([]);
+interface Props {
+  techStacks: TechStack[];
+}
+
+function TechStackInput({ techStacks: baseTechStackList }: Props): JSX.Element {
   const [filteredTechStackList, setFilteredTechStackList] = useState<TechStack[]>([]);
   const [techStackInput, setTechStackInput] = useState<string>('');
 
   const handleTechStackInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTechStackInput(e.target.value);
   };
-
-  useEffect(() => {
-    const getData = async () => {
-      const data = await getTechStackList();
-      setBaseTechStackList(data);
-    };
-    getData();
-  }, []);
 
   useEffect(() => {
     const newFilteredTechStackList = baseTechStackList.filter((techStack, idx) => {

--- a/client/src/pages/GroupCreatePage/TechStackInput/index.tsx
+++ b/client/src/pages/GroupCreatePage/TechStackInput/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { TechStack } from '../../../types/TechStack';
+import { TechStack } from '@types';
 import SearchBar from './SearchBar';
 import SelectedTechStackList from './SelectedTechStackList';
 import TechStackList from './TechStackList';

--- a/client/src/pages/GroupCreatePage/index.tsx
+++ b/client/src/pages/GroupCreatePage/index.tsx
@@ -14,6 +14,8 @@ import { clearGroupData } from '../../store/slices/createGroupData';
 import { Category, TechStack } from '../../types';
 import { getCategories } from '../../api/category';
 import { getTechStackList } from '../../api/techStack';
+import { GroupCreateInterface } from '../../types/ServerData';
+import { postGroupCreate } from '../../api/group';
 
 const MAX_CONTENT_INDEX = 4;
 
@@ -70,8 +72,28 @@ function GroupCreatePage(): JSX.Element {
 
     setNotificationText('');
     if (contentsNumber < MAX_CONTENT_INDEX) setContentsNumber(contentsNumber + 1);
+    else if (contentsNumber === MAX_CONTENT_INDEX) requestGroupCreate();
   };
 
+  const requestGroupCreate = async () => {
+    const groupCreateData: GroupCreateInterface = {
+      ownerId: 0,
+      name: groupData.groupName,
+      maxUserCnt: groupData.personnelCount,
+      curUserCnt: 1,
+      intro: groupData.groupInfo,
+      startAt: groupData.startDate,
+      endAt: groupData.endDate,
+      category: groupData.category,
+      usingTechStacks: groupData.selectedTechStack,
+    };
+    try {
+      await postGroupCreate(groupCreateData);
+      window.location.href = '/';
+    } catch (e) {
+      console.log(e);
+    }
+  };
   const cleanUp = () => {
     dispatch(clearGroupData());
   };
@@ -92,6 +114,7 @@ function GroupCreatePage(): JSX.Element {
 
     return () => cleanUp();
   }, []);
+
   return (
     <CreateForm>
       <GageBar contentsNumber={contentsNumber} />

--- a/client/src/pages/GroupCreatePage/index.tsx
+++ b/client/src/pages/GroupCreatePage/index.tsx
@@ -11,7 +11,6 @@ import { clearGroupData, groupCreateDataState } from '@store/slices/groupCreateD
 import { Category, TechStack } from '@types';
 import { getCategories } from '@api/category';
 import { getTechStackList } from '@api/techStack';
-import { GroupCreateInterface } from '@types';
 import { postGroupCreate } from '@api/group';
 import { useAppDispatch, useAppSelector } from '@hooks';
 
@@ -47,11 +46,11 @@ function GroupCreatePage(): JSX.Element {
       case 0:
         return groupData.category !== '';
       case 2:
-        return groupData.groupName !== '' && groupData.groupInfo !== '';
+        return groupData.name !== '' && groupData.intro !== '';
       case 3:
-        return groupData.startDate !== '' && groupData.endDate !== '';
+        return groupData.startAt !== '' && groupData.endAt !== '';
       case 4:
-        return groupData.selectedTechStack.length > 0;
+        return groupData.usingTechStacks.length > 0;
       default:
         return true;
     }
@@ -74,19 +73,8 @@ function GroupCreatePage(): JSX.Element {
   };
 
   const requestGroupCreate = async () => {
-    const groupCreateData: GroupCreateInterface = {
-      ownerId: 0,
-      name: groupData.groupName,
-      maxUserCnt: groupData.personnelCount,
-      curUserCnt: 1,
-      intro: groupData.groupInfo,
-      startAt: groupData.startDate,
-      endAt: groupData.endDate,
-      category: groupData.category,
-      usingTechStacks: groupData.selectedTechStack,
-    };
     try {
-      await postGroupCreate(groupCreateData);
+      await postGroupCreate(groupData);
       window.location.href = '/';
     } catch (e) {
       console.log(e);

--- a/client/src/pages/GroupCreatePage/index.tsx
+++ b/client/src/pages/GroupCreatePage/index.tsx
@@ -8,14 +8,14 @@ import GageBar from './GageBar';
 import CustomButton from './CustomButton';
 import styled from '@emotion/styled';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '../../store/rootReducer';
+import { ReducerType } from '@store/rootReducer';
 import { GroupData } from '../../types/CreateGroup';
-import { clearGroupData } from '../../store/slices/createGroupData';
-import { Category, TechStack } from '../../types';
-import { getCategories } from '../../api/category';
-import { getTechStackList } from '../../api/techStack';
-import { GroupCreateInterface } from '../../types/ServerData';
-import { postGroupCreate } from '../../api/group';
+import { clearGroupData } from '@store/slices/createGroupData';
+import { Category, TechStack } from '@types';
+import { getCategories } from '@api/category';
+import { getTechStackList } from '@api/techStack';
+import { GroupCreateInterface } from '@types';
+import { postGroupCreate } from '@api/group';
 
 const MAX_CONTENT_INDEX = 4;
 

--- a/client/src/pages/GroupCreatePage/index.tsx
+++ b/client/src/pages/GroupCreatePage/index.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import Category from './CategoryInput';
-import Personnel from './PersonnelInput';
-import TechStack from './TechStackInput';
-import GroupInfo from './GroupInfoInput';
-import Date from './DateInput';
+import CategoryInput from './CategoryInput';
+import PersonnelInput from './PersonnelInput';
+import TechStackInput from './TechStackInput';
+import GroupInfoInput from './GroupInfoInput';
+import DateInput from './DateInput';
 import GageBar from './GageBar';
 import CustomButton from './CustomButton';
 import styled from '@emotion/styled';
@@ -11,27 +11,32 @@ import { useDispatch, useSelector } from 'react-redux';
 import { ReducerType } from '../../store/rootReducer';
 import { GroupData } from '../../types/CreateGroup';
 import { clearGroupData } from '../../store/slices/createGroupData';
+import { Category, TechStack } from '../../types';
+import { getCategories } from '../../api/category';
+import { getTechStackList } from '../../api/techStack';
 
 const MAX_CONTENT_INDEX = 4;
 
 function GroupCreatePage(): JSX.Element {
   const [contentsNumber, setContentsNumber] = useState<number>(0);
   const [notificationText, setNotificationText] = useState<string>('');
+  const [categorys, setCategorys] = useState<Category[]>([]);
+  const [techStacks, setTechStacks] = useState<TechStack[]>([]);
   const groupData = useSelector<ReducerType, GroupData>((state) => state.createGroupData);
   const dispatch = useDispatch();
 
   const getContents = (): JSX.Element | null => {
     switch (contentsNumber) {
       case 0:
-        return <Category />;
+        return <CategoryInput categorys={categorys} />;
       case 1:
-        return <Personnel />;
+        return <PersonnelInput />;
       case 2:
-        return <GroupInfo />;
+        return <GroupInfoInput />;
       case 3:
-        return <Date />;
+        return <DateInput />;
       case 4:
-        return <TechStack />;
+        return <TechStackInput techStacks={techStacks} />;
       default:
         return null;
     }
@@ -51,6 +56,7 @@ function GroupCreatePage(): JSX.Element {
         return true;
     }
   };
+
   const clickPrevContents = () => {
     setNotificationText('');
     if (contentsNumber > 0) setContentsNumber(contentsNumber - 1);
@@ -66,13 +72,26 @@ function GroupCreatePage(): JSX.Element {
     if (contentsNumber < MAX_CONTENT_INDEX) setContentsNumber(contentsNumber + 1);
   };
 
-  const cleanUp = () =>{
+  const cleanUp = () => {
     dispatch(clearGroupData());
-  }
-  
-  useEffect(() =>{
+  };
+
+  useEffect(() => {
+    const fetchCategoryList = async () => {
+      const response: Category[] = await getCategories();
+      setCategorys(response);
+    };
+
+    const fetechTechStackList = async () => {
+      const response: TechStack[] = await getTechStackList();
+      setTechStacks(response);
+    };
+
+    fetchCategoryList();
+    fetechTechStackList();
+
     return () => cleanUp();
-  },[])
+  }, []);
   return (
     <CreateForm>
       <GageBar contentsNumber={contentsNumber} />

--- a/client/src/pages/GroupCreatePage/index.tsx
+++ b/client/src/pages/GroupCreatePage/index.tsx
@@ -7,15 +7,13 @@ import DateInput from './DateInput';
 import GageBar from './GageBar';
 import CustomButton from './CustomButton';
 import styled from '@emotion/styled';
-import { useDispatch, useSelector } from 'react-redux';
-import { ReducerType } from '@store/rootReducer';
-import { GroupData } from '../../types/CreateGroup';
-import { clearGroupData } from '@store/slices/createGroupData';
+import { clearGroupData, groupCreateDataState } from '@store/slices/groupCreateDataSlice';
 import { Category, TechStack } from '@types';
 import { getCategories } from '@api/category';
 import { getTechStackList } from '@api/techStack';
 import { GroupCreateInterface } from '@types';
 import { postGroupCreate } from '@api/group';
+import { useAppDispatch, useAppSelector } from '@hooks';
 
 const MAX_CONTENT_INDEX = 4;
 
@@ -24,8 +22,8 @@ function GroupCreatePage(): JSX.Element {
   const [notificationText, setNotificationText] = useState<string>('');
   const [categorys, setCategorys] = useState<Category[]>([]);
   const [techStacks, setTechStacks] = useState<TechStack[]>([]);
-  const groupData = useSelector<ReducerType, GroupData>((state) => state.createGroupData);
-  const dispatch = useDispatch();
+  const groupData = useAppSelector(groupCreateDataState);
+  const dispatch = useAppDispatch();
 
   const getContents = (): JSX.Element | null => {
     switch (contentsNumber) {

--- a/client/src/store/rootReducer.ts
+++ b/client/src/store/rootReducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import user from './slices/userSlice';
 import groupRecruit from './slices/groupRecruitFilterSlice';
-import createGroupData from './slices/createGroupData';
+import createGroupData from './slices/groupCreateDataSlice';
 
 const reducer = combineReducers({
   user,

--- a/client/src/store/slices/groupCreateDataSlice.ts
+++ b/client/src/store/slices/groupCreateDataSlice.ts
@@ -1,8 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { GroupData } from '../../types/CreateGroup';
+import { RootState } from '../index';
 
-export const createGroupDataSlice = createSlice({
-  name: 'createGroupData',
+export const groupCreateDataSlice = createSlice({
+  name: 'groupCreateData',
   initialState: {
     category: '',
     personnelCount: 1,
@@ -32,5 +33,6 @@ export const createGroupDataSlice = createSlice({
   },
 });
 
-export const { setGroupData, clearGroupData } = createGroupDataSlice.actions;
-export default createGroupDataSlice.reducer;
+export const { setGroupData, clearGroupData } = groupCreateDataSlice.actions;
+export default groupCreateDataSlice.reducer;
+export const groupCreateDataState = (state: RootState): GroupData => state.createGroupData;

--- a/client/src/store/slices/groupCreateDataSlice.ts
+++ b/client/src/store/slices/groupCreateDataSlice.ts
@@ -1,33 +1,37 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { GroupData } from '../../types/CreateGroup';
+import { GroupCreateInterface } from '@types';
 import { RootState } from '../index';
 
 export const groupCreateDataSlice = createSlice({
   name: 'groupCreateData',
   initialState: {
+    ownerId: 0,
+    name: '',
+    maxUserCnt: 1,
+    curUserCnt: 1,
+    intro: '',
+    startAt: '',
+    endAt: '',
     category: '',
-    personnelCount: 1,
-    startDate: '',
-    endDate: '',
-    groupName: '',
-    groupInfo: '',
-    selectedTechStack: [],
-  } as GroupData,
+    usingTechStacks: [],
+  } as GroupCreateInterface,
   reducers: {
     setGroupData(state, action) {
       const newData = action.payload;
       return { ...state, ...newData };
     },
     clearGroupData() {
-      const clearState: GroupData = {
+      const clearState: GroupCreateInterface = {
+        ownerId: 0,
+        name: '',
+        maxUserCnt: 1,
+        curUserCnt: 1,
+        intro: '',
+        startAt: '',
+        endAt: '',
         category: '',
-        personnelCount: 1,
-        startDate: '',
-        endDate: '',
-        groupName: '',
-        groupInfo: '',
-        selectedTechStack: [],
-      };
+        usingTechStacks: [],
+      } 
       return { ...clearState };
     },
   },
@@ -35,4 +39,4 @@ export const groupCreateDataSlice = createSlice({
 
 export const { setGroupData, clearGroupData } = groupCreateDataSlice.actions;
 export default groupCreateDataSlice.reducer;
-export const groupCreateDataState = (state: RootState): GroupData => state.createGroupData;
+export const groupCreateDataState = (state: RootState): GroupCreateInterface => state.createGroupData;

--- a/client/src/types/CreateGroup.ts
+++ b/client/src/types/CreateGroup.ts
@@ -1,9 +1,0 @@
-export interface GroupData {
-  category: string,
-  personnelCount: number,
-  startDate: string,
-  endDate: string,
-  groupName: string,
-  groupInfo: string,
-  selectedTechStack: string[]
-}

--- a/client/src/types/ServerData.ts
+++ b/client/src/types/ServerData.ts
@@ -2,10 +2,22 @@ export interface ExampleInterface {
   somethingToRequestKey: number;
 }
 
-export type RequestBody = ExampleInterface;
+export interface GroupCreateInterface {
+  ownerId: number;
+  name: string;
+  maxUserCnt: number;
+  curUserCnt: number;
+  intro: string;
+  startAt: string;
+  endAt: string;
+  category: string;
+	usingTechStacks: string[];
+}
 
 export interface ResponseGithubUserData {
   githubId: string;
   name: string;
   avatarUrl: string;
 }
+
+export type RequestBody = ExampleInterface | GroupCreateInterface;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,5 +1,5 @@
 export type { Category } from './Category';
 export type { BubbleModalProfileItem } from './Modal';
 export type { TechStack } from './TechStack';
-export type { ResponseGithubUserData } from './ServerData';
+export type { ResponseGithubUserData, GroupCreateInterface } from './ServerData';
 export type { Group, GroupResponse } from './Group';

--- a/server/src/domains/group/api/GroupController.ts
+++ b/server/src/domains/group/api/GroupController.ts
@@ -1,8 +1,9 @@
 import { UsingTechStackService } from '@domains/techstack/service/UsingTechStackService';
 import { ProfileService } from '@domains/user/service/ProfileService';
-import { Controller, Get } from 'routing-controllers';
+import { Body, Controller, Post } from 'routing-controllers';
 import { Inject, Service } from 'typedi';
 import { Group } from '../dto/groupDto';
+import { CreateGroupDto } from '../dto/CreateGroupDto';
 import { GroupService } from '../service/GroupService';
 
 @Service()
@@ -19,9 +20,14 @@ export class GroupController {
 
   @Get('/')
   async getAll() {
-    const groups: Group[] = await this.groupService.getGroups();
     const addedOtherGroupInfo = await this.addOtherGroupInfo(groups);
+    const groups: Group[] = await this.groupService.getGroups();
     return addedOtherGroupInfo;
+  }
+
+  @Post('/create')
+  create(@Body() groupData: CreateGroupDto) {
+    return this.groupService.createGroup(groupData);
   }
 
   addOtherGroupInfo(groups: Group[]) {

--- a/server/src/domains/group/api/GroupController.ts
+++ b/server/src/domains/group/api/GroupController.ts
@@ -1,11 +1,10 @@
 import { UsingTechStackService } from '@domains/techstack/service/UsingTechStackService';
 import { ProfileService } from '@domains/user/service/ProfileService';
-import { TechStackService } from '@domains/techstack/service/TechStackService';
-import { Body, Controller, OnUndefined, Post } from 'routing-controllers';
+import { Body, Controller, Get, OnUndefined, Post } from 'routing-controllers';
 import { Inject, Service } from 'typedi';
-import { Group } from '../dto/groupDto';
 import { CreateGroupDto } from '../dto/CreateGroupDto';
 import { GroupService } from '../service/GroupService';
+import { Group } from '../models/Group';
 
 @Service()
 @Controller('/group')
@@ -21,8 +20,8 @@ export class GroupController {
 
   @Get('/')
   async getAll() {
-    const addedOtherGroupInfo = await this.addOtherGroupInfo(groups);
     const groups: Group[] = await this.groupService.getGroups();
+    const addedOtherGroupInfo = await this.addOtherGroupInfo(groups);
     return addedOtherGroupInfo;
   }
 
@@ -30,7 +29,7 @@ export class GroupController {
   @OnUndefined(200)
   async create(@Body() groupData: CreateGroupDto) {
     const createdGroup = await this.groupService.createGroup(groupData);
-    this.techStackService.createGroupUsingStack(createdGroup, groupData.usingTechStacks);
+    this.usingTechStackService.createGroupUsingStack(createdGroup, groupData.usingTechStacks);
   }
 
   addOtherGroupInfo(groups: Group[]) {

--- a/server/src/domains/group/api/GroupController.ts
+++ b/server/src/domains/group/api/GroupController.ts
@@ -1,7 +1,7 @@
 import { UsingTechStackService } from '@domains/techstack/service/UsingTechStackService';
 import { ProfileService } from '@domains/user/service/ProfileService';
 import { TechStackService } from '@domains/techstack/service/TechStackService';
-import { Body, Controller, Post } from 'routing-controllers';
+import { Body, Controller, OnUndefined, Post } from 'routing-controllers';
 import { Inject, Service } from 'typedi';
 import { Group } from '../dto/groupDto';
 import { CreateGroupDto } from '../dto/CreateGroupDto';
@@ -27,11 +27,10 @@ export class GroupController {
   }
 
   @Post('/create')
+  @OnUndefined(200)
   async create(@Body() groupData: CreateGroupDto) {
     const createdGroup = await this.groupService.createGroup(groupData);
     this.techStackService.createGroupUsingStack(createdGroup, groupData.usingTechStacks);
-
-    return createdGroup;
   }
 
   addOtherGroupInfo(groups: Group[]) {

--- a/server/src/domains/group/api/GroupController.ts
+++ b/server/src/domains/group/api/GroupController.ts
@@ -1,5 +1,6 @@
 import { UsingTechStackService } from '@domains/techstack/service/UsingTechStackService';
 import { ProfileService } from '@domains/user/service/ProfileService';
+import { TechStackService } from '@domains/techstack/service/TechStackService';
 import { Body, Controller, Post } from 'routing-controllers';
 import { Inject, Service } from 'typedi';
 import { Group } from '../dto/groupDto';
@@ -26,8 +27,11 @@ export class GroupController {
   }
 
   @Post('/create')
-  create(@Body() groupData: CreateGroupDto) {
-    return this.groupService.createGroup(groupData);
+  async create(@Body() groupData: CreateGroupDto) {
+    const createdGroup = await this.groupService.createGroup(groupData);
+    this.techStackService.createGroupUsingStack(createdGroup, groupData.usingTechStacks);
+
+    return createdGroup;
   }
 
   addOtherGroupInfo(groups: Group[]) {

--- a/server/src/domains/group/dto/CreateGroupDto.ts
+++ b/server/src/domains/group/dto/CreateGroupDto.ts
@@ -1,0 +1,11 @@
+export interface CreateGroupDto {
+  ownerId: number;
+  name: string;
+  maxUserCnt: number;
+  curUserCnt: number;
+  intro: string;
+  startAt: string;
+  endAt: string;
+  category: string;
+  usingTechStacks: string[];
+}

--- a/server/src/domains/group/models/Group.ts
+++ b/server/src/domains/group/models/Group.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn, JoinColumn, OneToOne } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn, JoinColumn, OneToOne, ManyToOne } from 'typeorm';
 import { ApplyGroup } from './ApplyGroup';
 import { GroupEnrollment } from './GroupEnrollment';
 import { MentoringRequest } from '@domains/mentoring/models/MentoringRequest';
@@ -16,8 +16,8 @@ export class Group {
   @PrimaryGeneratedColumn({ name: 'group_id' })
   id: number;
 
-  @Column('int', { name: 'mentor_id' })
-  mentorId: number;
+  @Column('int', { name: 'mentor_id', nullable: true })
+  mentorId: number | null;
 
   @Column('int', { name: 'owner_id' })
   ownerId: number;
@@ -43,7 +43,7 @@ export class Group {
   @Column({ name: 'status', type: 'enum', enum: GroupState, default: GroupState.READY })
   status: GroupState;
 
-  @OneToOne(() => Category)
+  @ManyToOne((type) => Category)
   @JoinColumn({ name: 'category_id' })
   category: Category;
 

--- a/server/src/domains/group/repository/GroupRepository.ts
+++ b/server/src/domains/group/repository/GroupRepository.ts
@@ -9,6 +9,6 @@ export class GroupRepository extends Repository<Group> {
     return this.find();
   }
   public createGroup(group: Group) {
-    return this.insert(group);
+    return this.save(group);
   }
 }

--- a/server/src/domains/group/repository/GroupRepository.ts
+++ b/server/src/domains/group/repository/GroupRepository.ts
@@ -8,4 +8,7 @@ export class GroupRepository extends Repository<Group> {
   public findAll() {
     return this.find();
   }
+  public createGroup(group: Group) {
+    return this.insert(group);
+  }
 }

--- a/server/src/domains/group/service/GroupService.ts
+++ b/server/src/domains/group/service/GroupService.ts
@@ -17,10 +17,6 @@ export class GroupService {
     private readonly groupRepository: GroupRepository,
     @InjectRepository()
     private readonly categoryRepository: CategoryRepository,
-    @InjectRepository()
-    private readonly usingTechStackRepository: UsingTechStackRepository,
-    @InjectRepository()
-    private readonly techStackRepository: TechStackRepository,
   ) {}
 
   public async getGroups() {
@@ -44,19 +40,6 @@ export class GroupService {
     group.endAt = new Date(groupData.endAt);
 
     const createdGroup = await this.groupRepository.createGroup(group);
-
-    groupData.usingTechStacks.forEach(async (techStackName) => {
-      const techStack: TechStack = await this.techStackRepository.findOneOrFail({
-        where: { name: techStackName },
-      });
-      const usingTechStack: UsingTechStack = new UsingTechStack();
-
-      usingTechStack.group = createdGroup;
-      usingTechStack.techStack = techStack;
-      usingTechStack.type = UsingTechAs.GROUP;
-
-      this.usingTechStackRepository.createUsingTechStack(usingTechStack);
-    });
 
     return createdGroup;
   }

--- a/server/src/domains/group/service/GroupService.ts
+++ b/server/src/domains/group/service/GroupService.ts
@@ -5,10 +5,6 @@ import { Category } from "@domains/category/models/Category";
 import { CategoryRepository } from "@domains/category/repository/CategoryRepository";
 import { CreateGroupDto } from "../dto/CreateGroupDto";
 import { Group } from "../models/Group";
-import { TechStack } from '@domains/techstack/models/TechStack';
-import { UsingTechAs, UsingTechStack } from '@domains/techstack/models/UsingTechStack';
-import { TechStackRepository } from '@domains/techstack/repository/TechStackRepository';
-import { UsingTechStackRepository } from '@domains/techstack/repository/UsingTechStackRepository';
 
 @Service()
 export class GroupService {

--- a/server/src/domains/group/service/GroupService.ts
+++ b/server/src/domains/group/service/GroupService.ts
@@ -1,6 +1,10 @@
 import { Service } from 'typedi';
 import { GroupRepository } from '../repository/GroupRepository';
 import { InjectRepository } from 'typeorm-typedi-extensions';
+import { Category } from "@domains/category/models/Category";
+import { CategoryRepository } from "@domains/category/repository/CategoryRepository";
+import { CreateGroupDto } from "../dto/CreateGroupDto";
+import { Group } from "../models/Group";
 
 @Service()
 export class GroupService {
@@ -13,4 +17,20 @@ export class GroupService {
     const groups = await this.groupRepository.findAll();
     return groups;
   }
+
+    public async createGroup(groupData: CreateGroupDto) {
+        const group: Group = new Group();
+        
+        group.mentorId = 0;
+        group.ownerId = groupData.ownerId;
+        group.name = groupData.name;
+        group.maxUserCnt = groupData.maxUserCnt;
+        group.curUserCnt = groupData.curUserCnt;
+        group.intro = groupData.intro;
+        group.startAt = new Date(groupData.startAt);
+        group.endAt = new Date(groupData.endAt);
+
+
+        return this.groupRepository.createGroup(group);
+    }
 }

--- a/server/src/domains/techstack/repository/UsingTechStackRepository.ts
+++ b/server/src/domains/techstack/repository/UsingTechStackRepository.ts
@@ -18,4 +18,7 @@ export class UsingTechStackRepository extends Repository<UsingTechStack> {
 
     return groupTechStackJoinResult;
   }
+  public createUsingTechStack(usingTechStack: UsingTechStack) {
+    return this.save(usingTechStack);
+  }
 }

--- a/server/src/domains/techstack/service/TechStackService.ts
+++ b/server/src/domains/techstack/service/TechStackService.ts
@@ -1,16 +1,36 @@
 import { Service } from 'typedi';
 import { TechStackRepository } from '../repository/TechStackRepository';
 import { InjectRepository } from 'typeorm-typedi-extensions';
+import { Group } from '@domains/group/models/Group';
+import { TechStack } from '../models/TechStack';
+import { UsingTechAs, UsingTechStack } from '../models/UsingTechStack';
+import { UsingTechStackRepository } from '../repository/UsingTechStackRepository';
 
 @Service()
 export class TechStackService {
   constructor(
     @InjectRepository()
     private readonly techStackRepository: TechStackRepository,
+    @InjectRepository()
+    private readonly usingTechStackRepository: UsingTechStackRepository,
   ) {}
 
   public async getTechStackList() {
     const techStackList = await this.techStackRepository.findAll();
     return techStackList;
+  }
+  public async createGroupUsingStack(createdGroup: Group, usingTechStacks: string[]) {
+    usingTechStacks.forEach(async (techStackName) => {
+      const techStack: TechStack = await this.techStackRepository.findOneOrFail({
+        where: { name: techStackName },
+      });
+      const usingTechStack: UsingTechStack = new UsingTechStack();
+
+      usingTechStack.group = createdGroup;
+      usingTechStack.techStack = techStack;
+      usingTechStack.type = UsingTechAs.GROUP;
+
+      this.usingTechStackRepository.createUsingTechStack(usingTechStack);
+    });
   }
 }

--- a/server/src/domains/techstack/service/TechStackService.ts
+++ b/server/src/domains/techstack/service/TechStackService.ts
@@ -1,36 +1,16 @@
 import { Service } from 'typedi';
 import { TechStackRepository } from '../repository/TechStackRepository';
 import { InjectRepository } from 'typeorm-typedi-extensions';
-import { Group } from '@domains/group/models/Group';
-import { TechStack } from '../models/TechStack';
-import { UsingTechAs, UsingTechStack } from '../models/UsingTechStack';
-import { UsingTechStackRepository } from '../repository/UsingTechStackRepository';
 
 @Service()
 export class TechStackService {
   constructor(
     @InjectRepository()
     private readonly techStackRepository: TechStackRepository,
-    @InjectRepository()
-    private readonly usingTechStackRepository: UsingTechStackRepository,
   ) {}
 
   public async getTechStackList() {
     const techStackList = await this.techStackRepository.findAll();
     return techStackList;
-  }
-  public async createGroupUsingStack(createdGroup: Group, usingTechStacks: string[]) {
-    usingTechStacks.forEach(async (techStackName) => {
-      const techStack: TechStack = await this.techStackRepository.findOneOrFail({
-        where: { name: techStackName },
-      });
-      const usingTechStack: UsingTechStack = new UsingTechStack();
-
-      usingTechStack.group = createdGroup;
-      usingTechStack.techStack = techStack;
-      usingTechStack.type = UsingTechAs.GROUP;
-
-      this.usingTechStackRepository.createUsingTechStack(usingTechStack);
-    });
   }
 }

--- a/server/src/domains/techstack/service/UsingTechStackService.ts
+++ b/server/src/domains/techstack/service/UsingTechStackService.ts
@@ -3,12 +3,18 @@ import { InjectRepository } from 'typeorm-typedi-extensions';
 import { destructObject } from '@utils/Object';
 import { GroupTechStackListDto } from '../dto/groupTechStackListDto';
 import { UsingTechStackRepository } from '../repository/UsingTechStackRepository';
+import { Group } from '@domains/group/models/Group';
+import { TechStack } from '../models/TechStack';
+import { UsingTechAs, UsingTechStack } from '../models/UsingTechStack';
+import { TechStackRepository } from '../repository/TechStackRepository';
 
 @Service()
 export class UsingTechStackService {
   constructor(
     @InjectRepository()
     private readonly usingTechStackRepository: UsingTechStackRepository,
+    @InjectRepository()
+    private readonly techStackRepository: TechStackRepository,
   ) {}
 
   public async getGroupsTechStackList(groupId: number) {
@@ -21,5 +27,20 @@ export class UsingTechStackService {
         return name;
       }),
     );
+  }
+
+  public async createGroupUsingStack(createdGroup: Group, usingTechStacks: string[]) {
+    usingTechStacks.forEach(async (techStackName) => {
+      const techStack: TechStack = await this.techStackRepository.findOneOrFail({
+        where: { name: techStackName },
+      });
+      const usingTechStack: UsingTechStack = new UsingTechStack();
+
+      usingTechStack.group = createdGroup;
+      usingTechStack.techStack = techStack;
+      usingTechStack.type = UsingTechAs.GROUP;
+
+      this.usingTechStackRepository.createUsingTechStack(usingTechStack);
+    });
   }
 }


### PR DESCRIPTION
## 관련 이슈

- closes #20

## 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message 발생 유/무
- [x] Coding Convention 준수 유/무

## 작업 요약
> 작업 내역 요약
- GroupCreatePage 내부 GET요청 로직 구현
- POST 요청 로직 구현
- 기타 코드 개선 : alias hook type 통일 적용
## Preview

> 선택 사항
- Group 테이블 
![image](https://user-images.githubusercontent.com/55623688/140858440-3639bf41-207d-4e6a-badb-599c0d8f366b.png)
- UsingTechStack 테이블
![image](https://user-images.githubusercontent.com/55623688/140858481-72cd25e7-303d-4d16-bd5e-4d9c2f14eb10.png)

## PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
> 백로그에 없지만 필요하여 구현한 기능 

- Group.OwnerId는 아직 몰라서 0으로 저장하도록 했습니다!
- Group.mentoId경우 처음 그룹생성시 없을 수 있기 때문에 Nullable로 변경했습니다.
- Group.Category를 ManyToOne으로 변경했습니다
- UsingTechStack.techStack을 ManyToOne으로 변경했습니다.
- 기본적인 POST 요청할때 발생하는 DB저장 로직은 그룹을 만들고 받아온 usingTechStack 배열의 기술스택을 그룹과 매핑시켜서 저장하도록 동작합니다. 
