### PR TITLE
[FE] feat: 박스 모달 컴포넌트 추가

### DIFF
--- a/client/src/components/BoxModal/index.tsx
+++ b/client/src/components/BoxModal/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+interface Style {
+  width?: string;
+  height?: string;
+  padding?: string;
+  background?: string;
+}
+interface Props {
+  style?: Style;
+  element?: JSX.Element;
+  onCancel: () => void;
+}
+
+function BoxModal({ style, element, onCancel }: Props): JSX.Element {
+  return (
+    <Container>
+      <Background onClick={onCancel} />
+      <Modal style={style}>{element}</Modal>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+`;
+
+const Background = styled.div`
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(47, 47, 47, 0.65);
+`;
+
+const Modal = styled.div`
+  width: ${(props) => props?.style?.width ?? '480px'};
+  height: ${(props) => props?.style?.height ?? '600px'};
+  background: ${(props) => props?.style?.background ?? 'white'};
+  border-radius: 28px;
+  box-shadow: 0 2px 4px 0 hsl(0deg 0% 81% / 50%);
+  padding: ${(props) => props?.style?.padding ?? '24px'};
+  box-sizing: border-box;
+  z-index: 9999;
+`;
+
+export default BoxModal;

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -1,6 +1,7 @@
 export { default as DefaultLayout } from './Layout';
 export { default as Header } from './Header';
 export { default as BubbleModal } from './BubbleModal';
+export { default as BoxModal } from './BoxModal';
 export { default as LinkButton } from './LinkButton';
 export { default as Auth } from './Auth';
 export { default as Loader } from './Loader';


### PR DESCRIPTION
## 관련 이슈

- closes #8

## 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [ ] Warning Message 발생 유/무
- [x] Coding Convention 준수 유/무

## 작업 요약
> 작업 내역 요약
- 박스 모달을 컴포넌트화

## Preview

<img width="1214" alt="스크린샷 2021-11-10 오후 3 18 16" src="https://user-images.githubusercontent.com/54929514/141060369-079e9dba-8378-432b-ab56-8f548449a0e0.png">

## PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
> 백로그에 없지만 필요하여 구현한 기능 

- 박스 모달을 재사용가능하도록 제작했습니다.
- 용법은 아래와 같습니다.

```javascript
import React, { useState } from 'react';
import { BoxModal } from '@components';


export function TestComponent():JSX.Element {
  const [isModal, setIsModal] = useState<boolean>(true);
  const handleModalBackgroundClick = () => setIsModal(false);
  const modalContent = <div>모달 내용</div>;

  return (
    <>
    {isModal && (
        <BoxModal
          style={{
            width: '400px',
            height: '50vh',
            padding: '24px 0px 24px 0px',
            background: '#992f99',
          }}
          element={modalContent}
          onCancle={handleModalBackgroundClick}
        />
      )}
    </>
  )
};
```

