### PR TITLE
[BE] Auth 및 User 라우터 swagger 설정

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -38,6 +38,7 @@
         "@types/morgan": "^1.9.3",
         "@types/multer": "^1.4.7",
         "@types/node": "^16.10.9",
+        "@types/swagger-ui-express": "^4.1.3",
         "nodemon": "^2.0.13",
         "ts-node": "^10.3.0",
         "tsconfig-paths": "^3.11.0"
@@ -241,6 +242,16 @@
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/validator": {
@@ -4115,6 +4126,16 @@
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/validator": {

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,7 @@
     "@types/morgan": "^1.9.3",
     "@types/multer": "^1.4.7",
     "@types/node": "^16.10.9",
+    "@types/swagger-ui-express": "^4.1.3",
     "nodemon": "^2.0.13",
     "ts-node": "^10.3.0",
     "tsconfig-paths": "^3.11.0"

--- a/server/src/domains/auth/api/AuthContorller.ts
+++ b/server/src/domains/auth/api/AuthContorller.ts
@@ -62,6 +62,14 @@ export class AuthController {
 
   @Get('/logout')
   @OnUndefined(204)
+  @OpenAPI({
+    summary: '사용자 로그아웃하는 API',
+    responses: {
+      '204': {
+        description: '로그아웃 완료',
+      },
+    },
+  })
   async postLogout(@Session() session: any) {
     session.destroy();
   }

--- a/server/src/domains/auth/api/AuthContorller.ts
+++ b/server/src/domains/auth/api/AuthContorller.ts
@@ -8,7 +8,11 @@ import {
 } from 'routing-controllers';
 import { Inject, Service } from 'typedi';
 import { AuthService } from '../service/AuthService';
+import { UserDto } from '@domains/user/dto/UserDto';
+import { NobodyDto } from '../dto/AuthDto';
+import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 
+@OpenAPI({ tags: ['인증'] })
 @Service()
 @Controller('/auth')
 export class AuthController {
@@ -18,6 +22,15 @@ export class AuthController {
   ) {}
 
   @Get('/silent-refresh')
+  @OpenAPI({
+    summary: '유저 세션 정보를 조회하는 API',
+    responses: {
+      '203': {
+        description: '유저 세션 정보 없음',
+      },
+    },
+  })
+  @ResponseSchema(UserDto, { description: '유저 세션 정보 있음' })
   @OnUndefined(203)
   async getAuthentification(
     @SessionParam('githubId') githubId: string,
@@ -25,7 +38,7 @@ export class AuthController {
   ) {
     if (!githubId) return;
     const userData = await this.authService.getUserProfile(githubId);
-    return { ...userData, role: role };
+    return { ...userData, role: role } as UserDto;
   }
 
   @Get('/token')

--- a/server/src/domains/auth/api/AuthContorller.ts
+++ b/server/src/domains/auth/api/AuthContorller.ts
@@ -8,8 +8,8 @@ import {
 } from 'routing-controllers';
 import { Inject, Service } from 'typedi';
 import { AuthService } from '../service/AuthService';
+import { GithubUserDto } from '../dto/AuthDto';
 import { UserDto } from '@domains/user/dto/UserDto';
-import { NobodyDto } from '../dto/AuthDto';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 
 @OpenAPI({ tags: ['인증'] })
@@ -22,6 +22,7 @@ export class AuthController {
   ) {}
 
   @Get('/silent-refresh')
+  @OnUndefined(203)
   @OpenAPI({
     summary: '유저 세션 정보를 조회하는 API',
     responses: {
@@ -31,7 +32,6 @@ export class AuthController {
     },
   })
   @ResponseSchema(UserDto, { description: '유저 세션 정보 있음' })
-  @OnUndefined(203)
   async getAuthentification(
     @SessionParam('githubId') githubId: string,
     @SessionParam('role') role: string,
@@ -42,6 +42,8 @@ export class AuthController {
   }
 
   @Get('/token')
+  @OpenAPI({ summary: 'Github OAuth 토큰을 발급받는 API' })
+  @ResponseSchema(GithubUserDto, { description: '토큰 정상 발급' })
   async getGithubAccessToken(
     @Session() session: any,
     @SessionParam('githubId') githubId: string,

--- a/server/src/domains/auth/dto/AuthDto.ts
+++ b/server/src/domains/auth/dto/AuthDto.ts
@@ -1,5 +1,10 @@
-export interface GithubUserDto {
+import { IsString } from 'class-validator';
+
+export class GithubUserDto {
+  @IsString()
   githubId: string;
+  @IsString()
   name: string;
+  @IsString()
   avatarUrl: string;
 }

--- a/server/src/domains/user/api/UserContorller.ts
+++ b/server/src/domains/user/api/UserContorller.ts
@@ -7,12 +7,22 @@ import {
   OnUndefined,
 } from 'routing-controllers';
 import { Inject, Service } from 'typedi';
+import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 
+@OpenAPI({ tags: ['사용자'] })
 @Service()
 @Controller('/user')
 export class UserController {
   @Patch('/role')
   @OnUndefined(200)
+  @OpenAPI({
+    summary: '사용자 역할 상태를 변경시키는 API',
+    responses: {
+      '200': {
+        description: '역할 변경 성공',
+      },
+    },
+  })
   async patchRole(
     @Session() session: any,
     @SessionParam('githubId') githubId: string,

--- a/server/src/domains/user/dto/UserDto.ts
+++ b/server/src/domains/user/dto/UserDto.ts
@@ -1,8 +1,18 @@
-export interface UserDto {
+import { IsNumber, IsString } from 'class-validator';
+
+export class UserDto {
+  @IsNumber()
   id: number;
+  @IsString()
   githubId: string;
+  @IsString()
   name: string;
+  @IsString()
   avatarUrl: string;
+  @IsNumber()
   feverStack: number;
+  @IsNumber()
   shareStack: number;
+  @IsString()
+  role?: string;
 }


### PR DESCRIPTION
## 관련 이슈

-  #98

## 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [ ] Warning Message 발생 유/무
- [x] Coding Convention 준수 유/무

## 작업 요약
> 작업 내역 요약
Auth 라우터 전체에 swagger 설정을 완료했습니다.
User 라우터의 /api/user/role API에 swagger 설정을 완료했습니다.

## PR 특이 사항
class-validator를 위해 interface를 class로 변경하는 것이 약간 불편합니다.. (무거워지는 행위 같아서..)
swagger 문서 자동화를 하기 위해선 어쩔 수 없겠죠? 큰 차이도 없을 것 같긴 합니다..
