### PR TITLE
[BE] 백엔드 코어 - findOrFail 사용을위한 EntityNotFound 에러 핸들러

### DIFF
--- a/server/src/common/error/ErrorCode.ts
+++ b/server/src/common/error/ErrorCode.ts
@@ -3,6 +3,7 @@ import { ErrorSpec } from './ErrorSpec';
 export const ErrorCode = Object.freeze({
   // basic
   BAD_REQUEST: new ErrorSpec('B100', '사용자 입력 에러'),
+  ENTITY_NOT_FOUND: new ErrorSpec('B101', ''),
   // auth
   NOT_LOGGED_IN: new ErrorSpec('A000', '로그인이 필요합니다.'),
   NOT_AUTHORIZED: new ErrorSpec('A001', '잘못된 권한입니다.'),

--- a/server/src/common/error/ErrorResponse.ts
+++ b/server/src/common/error/ErrorResponse.ts
@@ -2,6 +2,7 @@ import { BusinessLogicError } from './BusinessLogicError';
 import { ValidationError } from 'class-validator';
 import { ErrorSpec } from './ErrorSpec';
 import { ErrorCode } from './ErrorCode';
+import { EntityNotFoundError } from 'typeorm/error/EntityNotFoundError';
 
 type BadRequestError = {
   httpCode: number;
@@ -29,5 +30,11 @@ export class ErrorResponse {
     const { httpCode } = error;
     const errorSpec = ErrorCode.BAD_REQUEST;
     return new ErrorResponse(httpCode, errorSpec, error.errors);
+  }
+
+  static fromEntityNotFoundError(error: EntityNotFoundError): ErrorResponse {
+    const errorSpec = ErrorCode.ENTITY_NOT_FOUND;
+    errorSpec.description = error.message;
+    return new ErrorResponse(400, errorSpec);
   }
 }

--- a/server/src/common/error/handler/BusinessLogicErrorHandler.ts
+++ b/server/src/common/error/handler/BusinessLogicErrorHandler.ts
@@ -3,6 +3,7 @@ import { Service } from 'typedi';
 import { ErrorResponse } from '../ErrorResponse';
 import { BusinessLogicError } from '../BusinessLogicError';
 import { logger } from '@utils/logger';
+import { EntityNotFoundError } from 'typeorm/error/EntityNotFoundError';
 
 @Service()
 @Middleware({ type: 'after' })
@@ -12,6 +13,9 @@ export class BusinessLogicErrorHandler implements ExpressErrorMiddlewareInterfac
       logger.error(`[CODE:${error.errorSpec.code}] ${error.name} ${error.message}`);
       console.log(error);
       response.status(error.httpCode).send(ErrorResponse.fromBusniessLogicError(error));
+    } else if (error instanceof EntityNotFoundError) {
+      logger.error(error);
+      response.status(400).send(ErrorResponse.fromEntityNotFoundError(error));
     } else {
       next(error);
     }


### PR DESCRIPTION
## 관련 이슈

- closes #164

## 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message 발생 유/무
- [x] Coding Convention 준수 유/무
- [x] test 통과 여부

## 작업 요약
> 작업 내역 요약

EntityNotFound 용 핸들러를 달았습니다.

## Preview

> 선택 사항

## PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
> 백로그에 없지만 필요하여 구현한 기능 

이미 구현 해둔거는 리팩토링 기간에 바꾸고
앞으로 개발할 것들만 notfound 예외는 if문 검사하지않고 findOrFail 을 써주세요
