### PR TITLE
[FE] 토스트 UI 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "react-redux": "^7.2.6",
         "react-router-dom": "^5.3.0",
         "react-scripts": "4.0.3",
+        "react-toastify": "^8.1.0",
         "redux": "^4.1.2",
         "typescript": "^4.4.4",
         "web-vitals": "^1.1.2"
@@ -6705,6 +6706,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -18722,6 +18731,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.1.0.tgz",
+      "integrity": "sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -29242,6 +29263,11 @@
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -38468,6 +38494,14 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
           "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
         }
+      }
+    },
+    "react-toastify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.1.0.tgz",
+      "integrity": "sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "read-pkg": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "react-redux": "^7.2.6",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-toastify": "^8.1.0",
     "redux": "^4.1.2",
     "typescript": "^4.4.4",
     "web-vitals": "^1.1.2"

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -32,6 +32,8 @@ function Header(): JSX.Element {
 }
 
 const Container = styled.div`
+  position: sticky;
+  top: 0px;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -40,8 +42,10 @@ const Container = styled.div`
   min-width: 1040px;
   height: 80px;
   padding: 12px 32px 0px 32px;
+  background-color: ${(props) => props.theme.White};
   box-sizing: border-box;
   box-shadow: 0 2px 4px 0 hsl(0deg 0% 81% / 50%);
+  z-index: 9999;
 `;
 
 const Content = styled.div`

--- a/client/src/components/Layout/index.tsx
+++ b/client/src/components/Layout/index.tsx
@@ -17,6 +17,7 @@ const DefaultLayout = (): JSX.Element => {
         style={{ top: '90px' }}
         position="top-right"
         autoClose={3000}
+        limit={1}
         hideProgressBar
         pauseOnFocusLoss
         draggable

--- a/client/src/components/Layout/index.tsx
+++ b/client/src/components/Layout/index.tsx
@@ -3,6 +3,8 @@ import { Header, Loader } from '@components';
 import Router from '@core/Router';
 import { useAppSelector } from '@hooks';
 import { selectLoadingState } from '@store/util/Slice';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 const DefaultLayout = (): JSX.Element => {
   const isLoading = useAppSelector(selectLoadingState);
@@ -11,6 +13,15 @@ const DefaultLayout = (): JSX.Element => {
       <Header />
       <Router />
       {isLoading && <Loader />}
+      <ToastContainer
+        style={{ top: '90px' }}
+        position="top-right"
+        autoClose={3000}
+        hideProgressBar
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+      />
     </>
   );
 };

--- a/client/src/constants/consts.ts
+++ b/client/src/constants/consts.ts
@@ -2,7 +2,15 @@
 export const MSG_NOT_FOUND = '없는 페이지입니다';
 export const MSG_BAD_ACCESS = '좋지 못한 접근입니다.';
 export const MSG_NEED_INFO = '필수 입력사항을 입력해주세요!';
+
+export const MSG_POST_CREATE_SUCCESS = '게시글이 작성되었습니다.';
+export const MSG_POST_UPDATE_SUCCESS = '게시글이 수정되었습니다.';
+export const MSG_POST_DELETE_SUCCESS = '게시글이 삭제되었습니다.';
+
 export const MSG_GROUP_CREATE_ERROR = '그룹생성에 실패했습니다.';
+export const MSG_POST_CREATE_ERROR = '게시글 작성이 실패했습니다.';
+export const MSG_POST_UPDATE_ERROR = '게시글 수정이 실패했습니다.';
+export const MSG_POST_DELETE_ERROR = '게시글 삭제가 실패했습니다.';
 
 // 디스크립션
 export const DESC_NOT_FOUND = '404 NOT FOUND';

--- a/client/src/constants/consts.ts
+++ b/client/src/constants/consts.ts
@@ -1,6 +1,8 @@
 // 메시지
 export const MSG_NOT_FOUND = '없는 페이지입니다';
 export const MSG_BAD_ACCESS = '좋지 못한 접근입니다.';
+export const MSG_NEED_INFO = '필수 입력사항을 입력해주세요!';
+export const MSG_GROUP_CREATE_ERROR = '그룹생성에 실패했습니다.';
 
 // 디스크립션
 export const DESC_NOT_FOUND = '404 NOT FOUND';

--- a/client/src/constants/enums.ts
+++ b/client/src/constants/enums.ts
@@ -1,3 +1,6 @@
-export enum TempEnum {
-  temp = 'TEMP',
+export enum ToastMessageEnum {
+  INFO = 'INFO',
+  SUCCESS = 'SUCCESS',
+  WARNING = 'WARNING',
+  ERROR = 'ERROR',
 }

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './store';
 export * from './useSilentRefresh';
 export * from './useLoader';
+export * from './useToast';

--- a/client/src/hooks/useToast.ts
+++ b/client/src/hooks/useToast.ts
@@ -1,0 +1,27 @@
+import { toast } from 'react-toastify';
+import { ToastMessageEnum } from '@constants/enums';
+
+type ToastHookReturnType = [(message: string, type?: ToastMessageEnum) => void];
+
+export function useToast(): ToastHookReturnType {
+  const notify = (message: string, type?: ToastMessageEnum) => {
+    switch (type) {
+      case ToastMessageEnum.INFO:
+        toast.info(message);
+        break;
+      case ToastMessageEnum.SUCCESS:
+        toast.success(message);
+        break;
+      case ToastMessageEnum.WARNING:
+        toast.warning(message);
+        break;
+      case ToastMessageEnum.ERROR:
+        toast.error(message);
+        break;
+      default:
+        toast.info(message);
+        break;
+    }
+  };
+  return [notify];
+}

--- a/client/src/hooks/useToast.ts
+++ b/client/src/hooks/useToast.ts
@@ -1,10 +1,10 @@
 import { toast } from 'react-toastify';
 import { ToastMessageEnum } from '@constants/enums';
 
-type ToastHookReturnType = [(message: string, type?: ToastMessageEnum) => void];
+type ToastHookReturnType = [(message: string, type?: ToastMessageEnum | string) => void];
 
 export function useToast(): ToastHookReturnType {
-  const notify = (message: string, type?: ToastMessageEnum) => {
+  const notify = (message: string, type?: ToastMessageEnum | string) => {
     switch (type) {
       case ToastMessageEnum.INFO:
         toast.info(message);

--- a/client/src/pages/GroupCreatePage/index.tsx
+++ b/client/src/pages/GroupCreatePage/index.tsx
@@ -14,7 +14,6 @@ import { techStackHttpClient } from '@api';
 import { groupHttpClient } from '@api';
 import { useAppDispatch, useAppSelector, useToast } from '@hooks';
 import { selectUser } from '@store/user/globalSlice';
-import { ToastMessageEnum } from '@constants/enums';
 import { MSG_GROUP_CREATE_ERROR, MSG_NEED_INFO } from '@constants/consts';
 
 const MAX_CONTENT_INDEX = 4;
@@ -82,7 +81,7 @@ function GroupCreatePage(): JSX.Element {
 
   const clickNextContents = () => {
     if (!checkInput()) {
-      toastify(MSG_NEED_INFO, ToastMessageEnum.INFO);
+      toastify(MSG_NEED_INFO, 'INFO');
       return;
     }
 
@@ -98,7 +97,7 @@ function GroupCreatePage(): JSX.Element {
       await groupHttpClient.postGroupCreate(postGroupData);
       window.location.href = '/';
     } catch (e) {
-      toastify(MSG_GROUP_CREATE_ERROR, ToastMessageEnum.ERROR);
+      toastify(MSG_GROUP_CREATE_ERROR, 'ERROR');
     }
   };
   const cleanUp = () => {

--- a/client/src/pages/GroupCreatePage/index.tsx
+++ b/client/src/pages/GroupCreatePage/index.tsx
@@ -12,8 +12,10 @@ import { Category, TechStack } from '@types';
 import { categoryHttpClient } from '@api';
 import { techStackHttpClient } from '@api';
 import { groupHttpClient } from '@api';
-import { useAppDispatch, useAppSelector } from '@hooks';
+import { useAppDispatch, useAppSelector, useToast } from '@hooks';
 import { selectUser } from '@store/user/globalSlice';
+import { ToastMessageEnum } from '@constants/enums';
+import { MSG_GROUP_CREATE_ERROR, MSG_NEED_INFO } from '@constants/consts';
 
 const MAX_CONTENT_INDEX = 4;
 enum PAGE_NUMBER {
@@ -26,12 +28,12 @@ enum PAGE_NUMBER {
 
 function GroupCreatePage(): JSX.Element {
   const [contentsNumber, setContentsNumber] = useState<number>(0);
-  const [notificationText, setNotificationText] = useState<string>('');
   const [categorys, setCategorys] = useState<Category[]>([]);
   const [techStacks, setTechStacks] = useState<TechStack[]>([]);
   const groupData = useAppSelector(groupCreateDataState);
   const { id: ownerId } = useAppSelector(selectUser);
   const dispatch = useAppDispatch();
+  const [toastify] = useToast();
 
   const setUsingTechStacks = (newTechStacks: TechStack[]) =>
     dispatch(setGroupData({ techStacks: newTechStacks }));
@@ -74,34 +76,29 @@ function GroupCreatePage(): JSX.Element {
   };
 
   const clickPrevContents = () => {
-    setNotificationText('');
     if (contentsNumber > PAGE_NUMBER.CATEGORY) setContentsNumber(contentsNumber - 1);
     else window.history.back();
   };
 
   const clickNextContents = () => {
     if (!checkInput()) {
-      setNotificationText('필수 입력사항을 입력해주세요!');
+      toastify(MSG_NEED_INFO, ToastMessageEnum.INFO);
       return;
     }
 
-    setNotificationText('');
     if (contentsNumber < MAX_CONTENT_INDEX) setContentsNumber(contentsNumber + 1);
     else if (contentsNumber === MAX_CONTENT_INDEX) requestGroupCreate();
   };
 
   const requestGroupCreate = async () => {
     try {
-      if (ownerId === undefined) {
-        setNotificationText('로그인 정보가 없습니다...');
-        return;
-      }
+      if (!ownerId) return;
       const postGroupData = { ...groupData };
       postGroupData.ownerId = ownerId;
       await groupHttpClient.postGroupCreate(postGroupData);
       window.location.href = '/';
     } catch (e) {
-      setNotificationText('그룹생성에 실패했습니다...');
+      toastify(MSG_GROUP_CREATE_ERROR, ToastMessageEnum.ERROR);
     }
   };
   const cleanUp = () => {
@@ -129,7 +126,6 @@ function GroupCreatePage(): JSX.Element {
     <CreateForm>
       <GageBar contentsNumber={contentsNumber} />
       <ContentsContainer>{getContents()}</ContentsContainer>
-      <Notification>{notificationText}</Notification>
       <ButtonWrapper>
         <CustomButton label={'이전'} clickBtn={clickPrevContents} />
         <CustomButton
@@ -167,13 +163,4 @@ const ButtonWrapper = styled.div`
   margin: 0 40px 40px 0;
 `;
 
-const Notification = styled.div`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  font-size: 13px;
-  margin-left: 40px;
-  margin-bottom: 40px;
-  color: ${(props) => props.theme.Error}; ;
-`;
 export default GroupCreatePage;

--- a/client/src/pages/GroupsPage/GroupInfo/GroupIntroduction.tsx
+++ b/client/src/pages/GroupsPage/GroupInfo/GroupIntroduction.tsx
@@ -24,6 +24,7 @@ const Content = styled.p`
   font-size: 0.9rem;
   font-weight: 700;
   color: ${(props) => props.theme.Gray1};
+  white-space: pre;
 `;
 
 export default GroupIntrodction;

--- a/client/src/pages/GroupsPage/Modal/ReadModal/index.tsx
+++ b/client/src/pages/GroupsPage/Modal/ReadModal/index.tsx
@@ -1,17 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import styled from '@emotion/styled';
-import { useAppDispatch, useAppSelector } from '@hooks';
 import { postHttpClient } from '@api';
+import { useAppDispatch, useAppSelector, useToast } from '@hooks';
 import { changeGroupModalState } from '@store/util/Slice';
 import { selectUser } from '@store/user/globalSlice';
 import { selectGroupDetail } from '@store/group/detailSlice';
 import { setPosts, selectChoosenPost } from '@store/group/postSlice';
 import { formatDateToString } from '@utils/Date';
+import { MSG_POST_DELETE_SUCCESS, MSG_POST_DELETE_ERROR } from '@constants/consts';
 import CancelIcon from '@assets/icon_cancel.png';
 
 function ReadModal(): JSX.Element {
   const dispatch = useAppDispatch();
+  const [toastify] = useToast();
   const user = useAppSelector(selectUser);
   const group = useAppSelector(selectGroupDetail);
   const post = useAppSelector(selectChoosenPost);
@@ -21,12 +23,13 @@ function ReadModal(): JSX.Element {
     if (!post) return;
     try {
       await postHttpClient.deletePost(post?.id, group.id);
+      toastify(MSG_POST_DELETE_SUCCESS, 'SUCCESS');
+      dispatch(changeGroupModalState('NONE'));
       const posts = await postHttpClient.getGroupPosts(group.id);
       dispatch(setPosts(posts));
     } catch (e: any) {
-      console.log(e.description);
+      toastify(MSG_POST_DELETE_ERROR, 'ERROR');
     }
-    dispatch(changeGroupModalState('NONE'));
   };
   const handleCancelButtonClick = () => dispatch(changeGroupModalState('NONE'));
 


### PR DESCRIPTION
## 관련 이슈

- closes #201 

## 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [ ] Warning Message 발생 유/무
- [x] Coding Convention 준수 유/무
- [x] test 통과 여부

## 작업 요약
> 작업 내역 요약
- toast UI 구현 완료 (useToast)
- 그룹 생성 페이지, 그룹 내부 페이지 로직에 추가

## Preview

![스크린샷 2021-11-27 오후 2 49 20](https://user-images.githubusercontent.com/54929514/143669762-20837b91-9f83-4dac-afbc-18dc660f285f.png)

## PR 특이 사항
- 헤더를 sticky로 변경했습니다. (더 자연스러운 것 같아서..!)
- 리팩토링 시 필요한 시나리오에 추가하면 될 것 같습니다.

